### PR TITLE
Could reach end of rulesFromJsonV4 method without returning a QList

### DIFF
--- a/logic/OneSixRule.cpp
+++ b/logic/OneSixRule.cpp
@@ -56,6 +56,7 @@ QList<std::shared_ptr<Rule>> rulesFromJsonV4(QJsonObject &objectWithRules)
 		// add a new OS rule
 		rules.append(OsRule::create(action, requiredOs, versionRegex));
 	}
+    return rules;
 }
 
 QJsonObject ImplicitRule::toJson()


### PR DESCRIPTION
It was possible for execution to reach the end of the rulesFromJsonV4
method without returning. This was causing a crash on OS X when parsing
rules inside an instance.
