### PR TITLE
Fix OS X packaging problem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,7 +535,7 @@ IF (MultiMC_INSTALL_SHARED_LIBS)
 
 	INSTALL(CODE "
 		file(GLOB_RECURSE QTPLUGINS
-			\"\${CMAKE_INSTALL_PREFIX}/${PLUGIN_DEST_DIR}/plugins/*${CMAKE_SHARED_LIBRARY_SUFFIX}\")
+                        \"\${CMAKE_INSTALL_PREFIX}/${PLUGIN_DEST_DIR}/*${CMAKE_SHARED_LIBRARY_SUFFIX}\")
 		include(BundleUtilities)
 		fixup_bundle(\"${APPS}\" \"\${QTPLUGINS}\" \"${DIRS}\")
 		" COMPONENT Runtime)


### PR DESCRIPTION
GLOB_RECURSE was pointing at the wrong directory - it needed to point
at the directories that had the dylib files in them to fix them so they
didn’t point at the local installed version of Qt
