### PR TITLE
Changed console font to Consolas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ tags
 # YouCompleteMe config stuff.
 .ycm_extra_conf.*
 
+build/

--- a/gui/ConsoleWindow.ui
+++ b/gui/ConsoleWindow.ui
@@ -19,6 +19,7 @@
      <widget class="QPlainTextEdit" name="text">
       <property name="font">
        <font>
+        <family>Consolas</family>
         <pointsize>10</pointsize>
        </font>
       </property>


### PR DESCRIPTION
Tell me if this causes any issues, it shouldn't. With Consolas, it looks more like a command terminal / console and the fixed-width looks better in most cases.

If you disagree with this, that is completely fine. This is clearly an aesthetic feature only.
