### PR TITLE
Ignore permsize warning in java8

### DIFF
--- a/logic/MinecraftProcess.cpp
+++ b/logic/MinecraftProcess.cpp
@@ -167,6 +167,11 @@ void MinecraftProcess::logOutput(QString line, MessageLevel::Enum defaultLevel, 
 	if (censor)
 		line = censorPrivateInfo(line);
 
+	if (line.contains("ignoring option PermSize="))
+	{
+		return;
+	}
+
 	emit log(line, level);
 }
 


### PR DESCRIPTION
The option does nothing in java 8, so ignore the warning.
