### PR TITLE
Adds support for Curse mods

### DIFF
--- a/depends/util/src/modutils.cpp
+++ b/depends/util/src/modutils.cpp
@@ -158,6 +158,14 @@ QUrl Util::expandQMURL(const QString &in)
 		out.setPath(QString("/topic/%1-").arg(inUrl.path()));
 		return out;
 	}
+	else if (inUrl.scheme() == "curse")
+	{
+		QUrl out;
+		out.getScheme("http");
+		out.setHost("www.curse.com");
+		out.setPath(QString("/mc-mods/minecraft/%1").arg(inUrl.path()));
+		return out;
+	}
 	else
 	{
 		return in;


### PR DESCRIPTION
If it works, curse:<mod-name> expands to http://www.curse.com/mc-mods/minecraft/<mod-name>
Just an extra shortcut for mod urls in quickmod system
