### PR TITLE
Added test support for curse: shortcut for mod urls

### DIFF
--- a/tests/tst_modutils.cpp
+++ b/tests/tst_modutils.cpp
@@ -75,6 +75,10 @@ private slots:
 		QTest::newRow("mcf")
 				<< "mcf:123456"
 				<< "http://www.minecraftforum.net/topic/123456-";
+				
+		QTest::newRow("curse")
+				<< "curse:buildcraft"
+				<< "http://www.curse.com/mc-mods/minecraft/buildcraft"
 	}
 	void test_expandQMURL()
 	{


### PR DESCRIPTION
curse:buildcraft expands to http://www.curse.com/mc-mods/minecraft/buildcraft
