### PR TITLE
Show a warning in the log if a library is missing

### DIFF
--- a/depends/launcher/org/multimc/onesix/OneSixLauncher.java
+++ b/depends/launcher/org/multimc/onesix/OneSixLauncher.java
@@ -101,7 +101,15 @@ public class OneSixLauncher implements Launcher
 		Utils.log("Libraries:");
 		for (String s : libraries)
 		{
-			Utils.log("  " + s);
+			File f = new File(s);
+			if (f.exists())
+			{
+				Utils.log("  " + s);
+			}
+			else
+			{
+				Utils.log("  " + s + " (missing)", "Warning");
+			}
 		}
 		Utils.log();
 


### PR DESCRIPTION
I've run into a situation where some of the required libraries were missing in the libraries folder. (This might have been caused by a connection issue on my side.)
Since I did not find a warning/error message in the log telling me a file is missing it took a while to find the cause.
I suggest to at least add a warning to the log (as done in the attached commit). Since in some cases Minecraft might work even though a library is missing I think the launch should not be instantly aborted when a file is missing.
