### PR TITLE
GH-3068 Fix icons overwriting each other if not needed

### DIFF
--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -107,7 +107,7 @@ void InstanceImportTask::processZipPack()
         root = mmcFound;
         m_modpackType = ModpackType::MultiMC;
     }
-    else if (technicFound)
+    else if(technicFound)
     {
         // process as Technic pack
         qDebug() << "Technic:" << technicFound;
@@ -445,11 +445,11 @@ void InstanceImportTask::processMultiMC()
         {
             // import icon
             auto iconList = ENV.icons();
-            if (iconList->iconFileExists(m_instIcon))
+            if (!iconList->iconFileExists(m_instIcon))
             {
-                iconList->deleteIcon(m_instIcon);
+                iconList->installIcon(importIconPath, m_instIcon);
             }
-            iconList->installIcons({importIconPath});
+            
         }
     }
     emitSucceeded();

--- a/launcher/icons/IIconList.h
+++ b/launcher/icons/IIconList.h
@@ -21,5 +21,5 @@ public:
     virtual void saveIcon(const QString &key, const QString &path, const char * format) const = 0;
     virtual bool iconFileExists(const QString &key) const = 0;
     virtual void installIcons(const QStringList &iconFiles) = 0;
-    virtual void installIcon(const QString &file, const QString &name) = 0;
+    virtual void installIcon(const QString &file, QString &name) = 0;
 };

--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -268,7 +268,7 @@ void IconList::installIcons(const QStringList &iconFiles)
             continue;
         
         const QString sourceHash = getIconHash(sourceFile);
-        QString sourceFileName = fileinfo.baseName();
+        QString sourceFileName = fileinfo.baseName().remove("_" + sourceHash).remove(sourceHash);
         sourceFileName = QString("%1_%2.%3").arg(sourceFileName, sourceHash, suffix);
         QString target = FS::PathCombine(m_dir.dirName(), sourceFileName);
         
@@ -283,7 +283,7 @@ void IconList::installIcons(const QStringList &iconFiles)
             if(sourceHash == targetHash)
                 continue;
             
-            QString targetFileName = fileinfo.baseName();
+            QString targetFileName = fileinfo.baseName().remove("_" + targetHash).remove(targetHash);
             targetFileName = QString("%1_%2.%3").arg(targetFileName, targetHash, suffix);
             targetFileName = FS::PathCombine(m_dir.dirName(), targetFileName);
             if(!targetFile.rename(targetFileName))
@@ -309,6 +309,7 @@ void IconList::installIcon(const QString &file, QString &name)
             return;
         
         const QString sourceHash = getIconHash(sourceFile);
+        name = name.remove("_" + sourceHash).remove(sourceHash);
         name = QString("%1_%2.%3").arg(name, sourceHash, suffix);
         QString target = FS::PathCombine(m_dir.dirName(), name);
         
@@ -323,7 +324,7 @@ void IconList::installIcon(const QString &file, QString &name)
             if(sourceHash == targetHash)
                 return;
             
-            QString targetFileName = QString(name);
+            QString targetFileName = QString(name).remove("_" + targetHash).remove(targetHash);
             targetFileName = QString("%1_%2.%3").arg(targetFileName, targetHash, suffix);
             targetFileName = FS::PathCombine(m_dir.dirName(), targetFileName);
             if(!targetFile.rename(targetFileName))

--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -22,6 +22,7 @@
 #include <QFileSystemWatcher>
 #include <QSet>
 #include <QDebug>
+#include <QCryptographicHash>
 
 #define MAX_SIZE 1024
 
@@ -255,28 +256,96 @@ void IconList::installIcons(const QStringList &iconFiles)
     for (QString file : iconFiles)
     {
         QFileInfo fileinfo(file);
-        if (!fileinfo.isReadable() || !fileinfo.isFile())
+        if(!fileinfo.isReadable() || !fileinfo.isFile())
             continue;
-        QString target = FS::PathCombine(m_dir.dirName(), fileinfo.fileName());
 
+        QFile sourceFile(file);
+        if(!sourceFile.open(QIODevice::ReadOnly))
+            continue;
+        
         QString suffix = fileinfo.suffix();
         if (suffix != "jpeg" && suffix != "png" && suffix != "jpg" && suffix != "ico" && suffix != "svg" && suffix != "gif")
             continue;
+        
+        const QString sourceHash = getIconHash(sourceFile);
+        QString sourceFileName = fileinfo.baseName();
+        sourceFileName = QString("%1_%2.%3").arg(sourceFileName, sourceHash, suffix);
+        QString target = FS::PathCombine(m_dir.dirName(), sourceFileName);
+        
+        if(QFile::exists(target))
+        {
+            QFile targetFile(target);
+            if(!targetFile.open(QIODevice::ReadOnly))
+                continue;
 
+            const QString targetHash = getIconHash(targetFile);
+            
+            if(sourceHash == targetHash)
+                continue;
+            
+            QString targetFileName = fileinfo.baseName();
+            targetFileName = QString("%1_%2.%3").arg(targetFileName, targetHash, suffix);
+            targetFileName = FS::PathCombine(m_dir.dirName(), targetFileName);
+            if(!targetFile.rename(targetFileName))
+                continue;
+        }
         if (!QFile::copy(file, target))
             continue;
     }
 }
 
-void IconList::installIcon(const QString &file, const QString &name)
+void IconList::installIcon(const QString &file, QString &name)
 {
-    QFileInfo fileinfo(file);
-    if(!fileinfo.isReadable() || !fileinfo.isFile())
-        return;
+        QFileInfo fileinfo(file);
+        if(!fileinfo.isReadable() || !fileinfo.isFile())
+            return;
 
-    QString target = FS::PathCombine(m_dir.dirName(), name);
+        QFile sourceFile(file);
+        if(!sourceFile.open(QIODevice::ReadOnly))
+            return;
+        
+        QString suffix = fileinfo.suffix();
+        if (suffix != "jpeg" && suffix != "png" && suffix != "jpg" && suffix != "ico" && suffix != "svg" && suffix != "gif")
+            return;
+        
+        const QString sourceHash = getIconHash(sourceFile);
+        name = QString("%1_%2.%3").arg(name, sourceHash, suffix);
+        QString target = FS::PathCombine(m_dir.dirName(), name);
+        
+        if(QFile::exists(target))
+        {
+            QFile targetFile(target);
+            if(!targetFile.open(QIODevice::ReadOnly))
+                return;
 
-    QFile::copy(file, target);
+            const QString targetHash = getIconHash(targetFile);
+            
+            if(sourceHash == targetHash)
+                return;
+            
+            QString targetFileName = QString(name);
+            targetFileName = QString("%1_%2.%3").arg(targetFileName, targetHash, suffix);
+            targetFileName = FS::PathCombine(m_dir.dirName(), targetFileName);
+            if(!targetFile.rename(targetFileName))
+                return;
+        }
+        if (!QFile::copy(file, target))
+            return;
+}
+
+const QString IconList::getIconHash(QFile& file)
+{
+    QByteArray iconByteArray = file.readAll();
+    const QString iconHash = QString(QCryptographicHash::hash((iconByteArray), QCryptographicHash::Md5).toHex());
+    return iconHash;
+}
+
+const QString IconList::getIconHash(const QString& fileName)
+{
+    QFile file(fileName);
+    if(!file.open(QIODevice::ReadOnly))
+        return "";
+    return getIconHash(file);
 }
 
 bool IconList::iconFileExists(const QString &key) const

--- a/launcher/icons/IconList.h
+++ b/launcher/icons/IconList.h
@@ -54,10 +54,13 @@ public:
     virtual Qt::ItemFlags flags(const QModelIndex &index) const override;
 
     void installIcons(const QStringList &iconFiles) override;
-    void installIcon(const QString &file, const QString &name) override;
-
+    void installIcon(const QString &file, QString &name) override;
+    
     const MMCIcon * icon(const QString &key) const;
 
+    const QString getIconHash(QFile& file);
+    const QString getIconHash(const QString& fileName);
+    
     void startWatching();
     void stopWatching();
 


### PR DESCRIPTION
When importing icons, mmc will now create an icon, with the filename and the md5 hash of the file appeneded to it.
`icon2.png` becomes `icon2_4190adsawewq.png` or similar. In case a file with that name already exists, both files are checked on their md5sum, if they equal, the new file isnt imported. If the files have different checksums, the existing file becomes reevaluated (should only happen if someone purpoesfully adds a wrong hash to a file ) and written to the actual name it should have. ideally, that should never happen.