### PR TITLE
GH-4125 Ignore stderr from JavaChecker

### DIFF
--- a/launcher/java/JavaChecker.cpp
+++ b/launcher/java/JavaChecker.cpp
@@ -69,7 +69,8 @@ void JavaChecker::stderrReady()
     QByteArray data = process->readAllStandardError();
     QString added = QString::fromLocal8Bit(data);
     added.remove('\r');
-    m_stderr += added;
+
+    qWarning() << "Forwarding error from JavaChecker" << added;
 }
 
 void JavaChecker::finished(int exitcode, QProcess::ExitStatus status)


### PR DESCRIPTION
It won't be valid output, and may sadly originate from the host OS.
