### PR TITLE
GH-4224 Scan 64 bit lib directory to find Java

### DIFF
--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -386,6 +386,7 @@ QList<QString> JavaUtils::FindJavaPaths()
     scanJavaDir("/usr/java");
     // general locations used by distro packaging
     scanJavaDir("/usr/lib/jvm");
+    scanJavaDir("/usr/lib64/jvm");
     scanJavaDir("/usr/lib32/jvm");
     // javas stored in MultiMC's folder
     scanJavaDir("java");


### PR DESCRIPTION
MultiMC is unable to find Java versions if they are in `/usr/lib64/jvm`. This is supposed to fix issue said issue (#4224).