### PR TITLE
GH-4200 Search Eclipse Foundation and Adoptium in Registry

### DIFF
--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -265,11 +265,17 @@ QList<QString> JavaUtils::FindJavaPaths()
     QList<JavaInstallPtr> ADOPTOPENJDK64s = this->FindJavaFromRegistryKey(
         KEY_WOW64_64KEY, "SOFTWARE\\AdoptOpenJDK\\JDK", "Path", "\\hotspot\\MSI");
 
-    // Adoptium (Eclipse)
-    QList<JavaInstallPtr> ECLIPSEJDK32s = this->FindJavaFromRegistryKey(
+    // Foundation (Eclipse)
+    QList<JavaInstallPtr> FOUNDATIONJDK32s = this->FindJavaFromRegistryKey(
         KEY_WOW64_32KEY, "SOFTWARE\\Eclipse Foundation\\JDK", "Path", "\\hotspot\\MSI");
-    QList<JavaInstallPtr> ECLIPSEJDK64s = this->FindJavaFromRegistryKey(
+    QList<JavaInstallPtr> FOUNDATIONJDK64s = this->FindJavaFromRegistryKey(
         KEY_WOW64_64KEY, "SOFTWARE\\Eclipse Foundation\\JDK", "Path", "\\hotspot\\MSI");
+
+    // Adoptium (Eclipse)
+    QList<JavaInstallPtr> ADOPTIUMJDK32s = this->FindJavaFromRegistryKey(
+        KEY_WOW64_32KEY, "SOFTWARE\\Eclipse Adoptium\\JDK", "Path", "\\hotspot\\MSI");
+    QList<JavaInstallPtr> ADOPTIUMJDK64s = this->FindJavaFromRegistryKey(
+        KEY_WOW64_64KEY, "SOFTWARE\\Eclipse Adoptium\\JDK", "Path", "\\hotspot\\MSI");
 
     // Microsoft
     QList<JavaInstallPtr> MICROSOFTJDK64s = this->FindJavaFromRegistryKey(
@@ -297,7 +303,8 @@ QList<QString> JavaUtils::FindJavaPaths()
     java_candidates.append(JDK64s);
     java_candidates.append(NEWJDK64s);
     java_candidates.append(ADOPTOPENJDK64s);
-    java_candidates.append(ECLIPSEJDK64s);
+    java_candidates.append(FOUNDATIONJDK64s);
+    java_candidates.append(ADOPTIUMJDK64s);
     java_candidates.append(MICROSOFTJDK64s);
     java_candidates.append(ZULU64s);
     java_candidates.append(LIBERICA64s);
@@ -311,7 +318,8 @@ QList<QString> JavaUtils::FindJavaPaths()
     java_candidates.append(JDK32s);
     java_candidates.append(NEWJDK32s);
     java_candidates.append(ADOPTOPENJDK32s);
-    java_candidates.append(ECLIPSEJDK32s);
+    java_candidates.append(FOUNDATIONJDK32s);
+    java_candidates.append(ADOPTIUMJDK32s);
     java_candidates.append(ZULU32s);
     java_candidates.append(LIBERICA32s);
     


### PR DESCRIPTION
MultiMC doesn't search `Eclipse Adoptium` in the registry to look for Java causing issue #4200. I do not have a Windows machine so if someone could test it, that would be great.