### PR TITLE
Install launcher icns to correct file name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,7 @@ if(Launcher_LAYOUT_REAL STREQUAL "mac-bundle")
     set(INSTALL_BUNDLE "full")
 
     # Add the icon
-    install(FILES ${Launcher_Branding_ICNS} DESTINATION ${RESOURCES_DEST_DIR})
+    install(FILES ${Launcher_Branding_ICNS} DESTINATION ${RESOURCES_DEST_DIR} RENAME ${Launcher_Name}.icns)
 
 elseif(Launcher_LAYOUT_REAL STREQUAL "lin-nodeps")
     set(BINARY_DEST_DIR "bin")


### PR DESCRIPTION
https://github.com/MultiMC/Launcher/blob/develop/CMakeLists.txt#L179 sets the launcher icon to `${Launcher_Name}.icns` but the installation logic previously didn't guarantee this name would be used for the file. This fixes that issue.