### PR TITLE
Fix instructions for building on Mac

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -194,7 +194,7 @@ cmake \
  -DCMAKE_C_COMPILER=/usr/bin/clang \
  -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
  -DCMAKE_BUILD_TYPE=Release \
- -DCMAKE_INSTALL_PREFIX:PATH="../dist/" \
+ -DCMAKE_INSTALL_PREFIX:PATH="$(dirname $PWD)/dist/" \
  -DCMAKE_PREFIX_PATH="/path/to/Qt5.6/" \
  -DQt5_DIR="/path/to/Qt5.6/" \
  -DLauncher_LAYOUT=mac-bundle \
@@ -202,3 +202,6 @@ cmake \
  ..
 make install
 ```
+
+**Note:** The final app bundle may not run due to code signing issues, which
+need to be fixed with `codesign -fs -`.


### PR DESCRIPTION
The current instructions don't work, and lead to errors like `cannot fixup an item that is not in the bundle...` (see https://github.com/MultiMC/Launcher/issues/3801). It seems that the current build rules do not properly handle relative paths or `..` path components.

The change also adds a note about potential problems due to code signing. I'm happy to provide more explicit instructions along those lines, but wasn't sure how much detail would be welcome in the doc.