### PR TITLE
Update Java version to 7+

### DIFF
--- a/libraries/javacheck/CMakeLists.txt
+++ b/libraries/javacheck/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
 project(launcher Java)
-find_package(Java 1.6 REQUIRED COMPONENTS Development)
+find_package(Java 7 REQUIRED COMPONENTS Development)
 
 include(UseJava)
 set(CMAKE_JAVA_JAR_ENTRY_POINT JavaCheck)
-set(CMAKE_JAVA_COMPILE_FLAGS -target 1.6 -source 1.6 -Xlint:deprecation -Xlint:unchecked)
+set(CMAKE_JAVA_COMPILE_FLAGS -target 7 -source 7 -Xlint:deprecation -Xlint:unchecked)
 
 set(SRC
     JavaCheck.java

--- a/libraries/launcher/CMakeLists.txt
+++ b/libraries/launcher/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
 project(launcher Java)
-find_package(Java 1.6 REQUIRED COMPONENTS Development)
+find_package(Java 7 REQUIRED COMPONENTS Development)
 
 include(UseJava)
 set(CMAKE_JAVA_JAR_ENTRY_POINT org.multimc.EntryPoint)
-set(CMAKE_JAVA_COMPILE_FLAGS -target 1.6 -source 1.6 -Xlint:deprecation -Xlint:unchecked)
+set(CMAKE_JAVA_COMPILE_FLAGS -target 7 -source 7 -Xlint:deprecation -Xlint:unchecked)
 
 set(SRC
     org/multimc/EntryPoint.java


### PR DESCRIPTION
Currently it doesn't build with newer Java unless I make this change.

Note that even for 7 I do get warning but atleast it builds fine :)
```
-- Found Java: /usr/bin/java (found suitable version "17.0.1", minimum required is "7") found components: Development 
warning: [options] bootstrap class path not set in conjunction with -source 7
warning: [options] source value 7 is obsolete and will be removed in a future release
warning: [options] target value 7 is obsolete and will be removed in a future release
```
