### PR TITLE
NOISSUE Ignore Install Directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ Debug
 build
 /build-*
 
+# Install dirs
+install
+/install-*
+
 # Ctags File
 tags
 


### PR DESCRIPTION
Hi!

In the `BUILD.md`, it instructs the builder to create a `build` directory. Since this directory should not be committed, this pull request adds it to the `.gitignore`.