### PR TITLE
GH-4299 Fix Screenshot upload

### DIFF
--- a/launcher/net/NetJob.cpp
+++ b/launcher/net/NetJob.cpp
@@ -98,6 +98,12 @@ void NetJob::partProgress(int index, qint64 bytesReceived, qint64 bytesTotal)
 
 void NetJob::executeTask()
 {
+    if(!m_network) {
+        qCritical() << "Attempted to start NetJob" << objectName() << "without the network set!";
+        emitFailed(tr("Internal error: NetJob '%1' has been started without a network pointer!").arg(objectName()));
+        return;
+    }
+
     // hack that delays early failures so they can be caught easier
     QMetaObject::invokeMethod(this, "startMoreParts", Qt::QueuedConnection);
 }

--- a/launcher/net/NetJob.h
+++ b/launcher/net/NetJob.h
@@ -67,15 +67,6 @@ public slots:
     virtual bool abort() override;
     virtual void start(shared_qobject_ptr<QNetworkAccessManager> network) {
         m_network = network;
-        start();
-    }
-
-protected slots:
-    void start() override {
-        if(!m_network) {
-            throw "Missing network while trying to start " + objectName();
-            return;
-        }
         Task::start();
     }
 

--- a/launcher/net/NetJob.h
+++ b/launcher/net/NetJob.h
@@ -35,6 +35,11 @@ public:
     }
     virtual ~NetJob();
 
+    void setNetwork(shared_qobject_ptr<QNetworkAccessManager> network)
+    {
+        m_network = network;
+    }
+
     bool addNetAction(NetAction::Ptr action);
 
     NetAction::Ptr operator[](int index)

--- a/launcher/ui/pages/instance/ScreenshotsPage.cpp
+++ b/launcher/ui/pages/instance/ScreenshotsPage.cpp
@@ -314,6 +314,8 @@ void ScreenshotsPage::on_actionUpload_triggered()
 
         m_uploadActive = true;
         ProgressDialog dialog(this);
+
+        job->setNetwork(APPLICATION->network());
         if(dialog.execWithTask(job.get()) != QDialog::Accepted)
         {
             CustomMessageBox::selectable(this, tr("Failed to upload screenshots!"),
@@ -348,7 +350,9 @@ void ScreenshotsPage::on_actionUpload_triggered()
     auto albumTask = NetJob::Ptr(new NetJob("Imgur Album Creation"));
     auto imgurAlbum = ImgurAlbumCreation::make(uploaded);
     albumTask->addNetAction(imgurAlbum);
+    job->setNetwork(APPLICATION->network());
     task.addTask(job);
+    albumTask->setNetwork(APPLICATION->network());
     task.addTask(albumTask);
     m_uploadActive = true;
     ProgressDialog prog(this);


### PR DESCRIPTION
Uploading screenshots has been broken since commit https://github.com/MultiMC/Launcher/commit/69213b1206e97f7d4db4270a4b3b0af41dc9e6fc due to NetJob's requiring a network manager pointer.

This PR addresses 2 issues:
- Don't hard crash MultiMC in case the pointer is missing
- Set the pointer for screenshot tasks

An additional method for setting the network has been added as task dialog boxes and sequential tasks call `start` directly on tasks with no chance of setting the network.