### PR TITLE
Fix error message

### DIFF
--- a/launcher/minecraft/auth/Parsers.cpp
+++ b/launcher/minecraft/auth/Parsers.cpp
@@ -94,7 +94,7 @@ bool parseXTokenResponse(QByteArray & data, Katabasis::Token &output, QString na
         return false;
     }
     if(!getString(obj.value("Token"), output.token)) {
-        qWarning() << "User Token is not a timestamp";
+        qWarning() << "User Token is not a string";
         return false;
     }
     auto arrayVal = obj.value("DisplayClaims").toObject().value("xui");


### PR DESCRIPTION
The code is trying to get a string from a json object, and if that fails it should log "is not a string", not "is not a timestamp".