### PR TITLE
Default value for MultiMC_MSA_CLIENT_ID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ set(MultiMC_DISCORD_URL "" CACHE STRING "URL for the Discord guild.")
 set(MultiMC_SUBREDDIT_URL "" CACHE STRING "URL for the subreddit.")
 
 # MSA Client ID
-set(MultiMC_MSA_CLIENT_ID "0d742867-f14f-4ad9-9d0b-13692c38dc3a" CACHE STRING "Client ID used for MSA authentication")
+set(MultiMC_MSA_CLIENT_ID "c158633f-4040-414a-b5fa-6d47a62424fd" CACHE STRING "Client ID used for MSA authentication")
 
 #### Check the current Git commit and branch
 include(GetGitRevisionDescription)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ set(MultiMC_DISCORD_URL "" CACHE STRING "URL for the Discord guild.")
 set(MultiMC_SUBREDDIT_URL "" CACHE STRING "URL for the subreddit.")
 
 # MSA Client ID
-set(MultiMC_MSA_CLIENT_ID "" CACHE STRING "Client ID used for MSA authentication")
+set(MultiMC_MSA_CLIENT_ID "0d742867-f14f-4ad9-9d0b-13692c38dc3a" CACHE STRING "Client ID used for MSA authentication")
 
 #### Check the current Git commit and branch
 include(GetGitRevisionDescription)


### PR DESCRIPTION
Friend showed me this trick:

BASH SCRIPT
```bash
wget -q -O - https://files.multimc.org/downloads/mmc-develop-lin32.tar.gz |
tar -x -z -O MultiMC/bin/MultiMC |
grep -a -o -E '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
```

OUTPUT

XXXXXXXX
c158633f-4040-414a-b5fa-6d47a62424fd
7ba9ce87-3228-4149-a329-890d534ae4e5
288c999c-9e93-4f90-9f65-6c947fa9fe63
1f283f9e-dda9-4cec-979d-e1c8a776d5d4

We used online tool https://paiza.io/projects/euW5TimrU01d2M8tofREdg?language=bash

API KEY is c158633f-4040-414a-b5fa-6d47a62424fd