### PR TITLE
NOISSUE Fix strings

### DIFF
--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -218,7 +218,7 @@ void InstanceImportTask::processFlame()
     }
     catch (const JSONValidationError &e)
     {
-        emitFailed(tr("Could not understand pack manifest:\n") + e.cause());
+        emitFailed(tr("Could not parse the pack manifest:\n") + e.cause());
         return;
     }
     if(!pack.overrides.isEmpty())

--- a/launcher/JavaCommon.cpp
+++ b/launcher/JavaCommon.cpp
@@ -8,9 +8,9 @@ bool JavaCommon::checkJVMArgs(QString jvmargs, QWidget *parent)
         || jvmargs.contains("-XX-MaxHeapSize") || jvmargs.contains("-XX:InitialHeapSize"))
     {
         auto warnStr = QObject::tr(
-            "You tried to manually set a JVM memory option (using \"-XX:PermSize\", \"-XX-MaxHeapSize\", \"-XX:InitialHeapSize\",  \"-Xmx\" or \"-Xms\").\n"
+            "An attempt was made to manually set a JVM memory option (using \"-XX:PermSize\", \"-XX-MaxHeapSize\", \"-XX:InitialHeapSize\",  \"-Xmx\" or \"-Xms\").\n"
             "There are dedicated boxes for these in the settings (Java tab, in the Memory group at the top).\n"
-            "This message will be displayed until you remove them from the JVM arguments.");
+            "This message will be displayed until these arguments are removed from the JVM arguments.");
         CustomMessageBox::selectable(
             parent, QObject::tr("JVM arguments warning"),
             warnStr,

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -55,9 +55,8 @@ void LaunchController::decideAccount()
         auto reply = CustomMessageBox::selectable(
             m_parentWidget,
             tr("No Accounts"),
-            tr("In order to play Minecraft, you must have at least one Mojang or Minecraft "
-               "account logged in."
-               "Would you like to open the account manager to add an account now?"),
+            tr("In order to play Minecraft, logging in to at least one Mojang or Microsoft account is required. "
+               "Open the account manager to add an account?"),
             QMessageBox::Information,
             QMessageBox::Yes | QMessageBox::No
         )->exec();
@@ -74,7 +73,7 @@ void LaunchController::decideAccount()
     {
         // If no default account is set, ask the user which one to use.
         ProfileSelectDialog selectDialog(
-            tr("Which account would you like to use?"),
+            tr("Select the account that should be used"),
             ProfileSelectDialog::GlobalDefaultCheckbox,
             m_parentWidget
         );
@@ -107,7 +106,7 @@ void LaunchController::login() {
     // we loop until the user succeeds in logging in or gives up
     bool tryagain = true;
     // the failure. the default failure.
-    const QString needLoginAgain = tr("Your account is currently not logged in. Please enter your password to log in again. <br /> <br /> This could be caused by a password change.");
+    const QString needLoginAgain = tr("Not currently logged in. Please enter the password to log in again.<br /><br />This could be caused by a password change.");
     QString failReason = needLoginAgain;
 
     while (tryagain)
@@ -129,7 +128,7 @@ void LaunchController::login() {
                     QString name = QInputDialog::getText(
                         m_parentWidget,
                         tr("Player name"),
-                        tr("Choose your offline mode player name."),
+                        tr("Choose an offline mode player name."),
                         QLineEdit::Normal,
                         m_session->player_name,
                         &ok
@@ -169,7 +168,7 @@ void LaunchController::login() {
                     // play demo ?
                     QMessageBox box(m_parentWidget);
                     box.setWindowTitle(tr("Play demo?"));
-                    box.setText(tr("This account does not own Minecraft.\nYou need to purchase the game first to play it.\n\nDo you want to play the demo?"));
+                    box.setText(tr("This account does not own Minecraft.\nPurchasing the game is required to play the full version.\n\nDo you want to play the demo?"));
                     box.setIcon(QMessageBox::Warning);
                     auto demoButton = box.addButton(tr("Play Demo"), QMessageBox::ButtonRole::YesRole);
                     auto cancelButton = box.addButton(tr("Cancel"), QMessageBox::ButtonRole::NoRole);
@@ -327,8 +326,8 @@ void LaunchController::readyForLaunch()
     connect(profilerInstance, &BaseProfiler::readyToLaunch, [this](const QString & message)
     {
         QMessageBox msg;
-        msg.setText(tr("The game launch is delayed until you press the "
-                        "button. This is the right time to setup the profiler, as the "
+        msg.setText(tr("The game launch is delayed until the button is pressed. "
+                        "This is the right time to setup the profiler, as the "
                         "profiler server is running now.\n\n%1").arg(message));
         msg.setWindowTitle(tr("Waiting."));
         msg.setIcon(QMessageBox::Information);
@@ -386,8 +385,8 @@ bool LaunchController::abort()
     }
     auto response = CustomMessageBox::selectable(
             m_parentWidget, tr("Kill Minecraft?"),
-            tr("This can cause the instance to get corrupted and should only be used if Minecraft "
-            "is frozen for some reason"),
+            tr("This can cause the instance to get corrupted and should only be done if Minecraft "
+            "is not responding"),
             QMessageBox::Question, QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes)->exec();
     if (response == QMessageBox::Yes)
     {

--- a/launcher/UpdateController.cpp
+++ b/launcher/UpdateController.cpp
@@ -412,7 +412,7 @@ void UpdateController::fail()
         if(!rollbackOK)
         {
             msg = QObject::tr("The rollback failed too.\n"
-                "You will have to repair %1 manually.\n"
+                "%1 will have to be repaired manually.\n"
                 "Please let us know why and how this happened.").arg(BuildConfig.LAUNCHER_NAME);
             QMessageBox::critical(m_parent, rollFailTitle, msg);
             qApp->quit();

--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -286,7 +286,7 @@ QVariant AccountList::data(const QModelIndex &index, int role) const
                         return tr("Working", "Account status");
                     }
                     case AccountState::Errored: {
-                        return tr("Error", "Account status");
+                        return tr("Errored", "Account status");
                     }
                     case AccountState::Expired: {
                         return tr("Expired", "Account status");

--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -286,7 +286,7 @@ QVariant AccountList::data(const QModelIndex &index, int role) const
                         return tr("Working", "Account status");
                     }
                     case AccountState::Errored: {
-                        return tr("Errored", "Account status");
+                        return tr("Error", "Account status");
                     }
                     case AccountState::Expired: {
                         return tr("Expired", "Account status");

--- a/launcher/minecraft/auth/steps/XboxAuthorizationStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxAuthorizationStep.cpp
@@ -124,8 +124,7 @@ bool XboxAuthorizationStep::processSTSError(
             case 2148916233:{
                 emit finished(
                     AccountTaskState::STATE_FAILED_SOFT,
-                    tr("This Microsoft account does not have an XBox Live profile. Buy the game on %1 first.")
-                        .arg("<a href=\"https://www.minecraft.net/en-us/store/minecraft-java-edition\">minecraft.net</a>")
+                    tr("This Microsoft account does not have an XBox Live profile. Purchasing the game on <a href=\"https://www.minecraft.net/en-us/store/minecraft-java-edition\">minecraft.net</a> is required.")
                 );
                 return true;
             }
@@ -133,22 +132,21 @@ bool XboxAuthorizationStep::processSTSError(
                 // NOTE: this is the Grulovia error
                 emit finished(
                     AccountTaskState::STATE_FAILED_SOFT,
-                    tr("XBox Live is not available in your country. You've been blocked.")
+                    tr("XBox Live is not available in this country. The provided account has been blocked.")
                 );
                 return true;
             }
             case 2148916238: {
                 emit finished(
                     AccountTaskState::STATE_FAILED_SOFT,
-                    tr("This Microsoft account is underaged and is not linked to a family.\n\nPlease set up your account according to %1.")
-                        .arg("<a href=\"https://help.minecraft.net/hc/en-us/articles/4403181904525\">help.minecraft.net</a>")
+                    tr("This is not an adult Microsoft account and it is not linked to a family.\n\nPlease set up the account according to <a href=\"https://help.minecraft.net/hc/en-us/articles/4403181904525\">help.minecraft.net</a>.")
                 );
                 return true;
             }
             default: {
                 emit finished(
                     AccountTaskState::STATE_FAILED_SOFT,
-                    tr("XSTS authentication ended with unrecognized error(s):\n\n%1").arg(errorCode)
+                    tr("XSTS authentication ended with an unrecognized error code:\n\n%1").arg(errorCode)
                 );
                 return true;
             }

--- a/launcher/minecraft/auth/steps/XboxAuthorizationStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxAuthorizationStep.cpp
@@ -124,7 +124,8 @@ bool XboxAuthorizationStep::processSTSError(
             case 2148916233:{
                 emit finished(
                     AccountTaskState::STATE_FAILED_SOFT,
-                    tr("This Microsoft account does not have an XBox Live profile. Purchasing the game on <a href=\"https://www.minecraft.net/en-us/store/minecraft-java-edition\">minecraft.net</a> is required.")
+                    tr("This Microsoft account does not have an Xbox Live profile. Purchasing the game on %1 is required.")
+                        .arg(tr("<a href=\"https://www.minecraft.net/en-us/store/minecraft-java-edition\">minecraft.net</a>"))
                 );
                 return true;
             }
@@ -132,14 +133,15 @@ bool XboxAuthorizationStep::processSTSError(
                 // NOTE: this is the Grulovia error
                 emit finished(
                     AccountTaskState::STATE_FAILED_SOFT,
-                    tr("XBox Live is not available in this country. The provided account has been blocked.")
+                    tr("Xbox Live is not available in this country. The provided account has been blocked by Microsoft.")
                 );
                 return true;
             }
             case 2148916238: {
                 emit finished(
                     AccountTaskState::STATE_FAILED_SOFT,
-                    tr("This is not an adult Microsoft account and it is not linked to a family.\n\nPlease set up the account according to <a href=\"https://help.minecraft.net/hc/en-us/articles/4403181904525\">help.minecraft.net</a>.")
+                    tr("This is not an adult Microsoft account and it is not linked to a family.\n\nPlease set up the account according to %1.")
+                        .arg("<a href=\"https://help.minecraft.net/hc/en-us/articles/4403181904525\">help.minecraft.net</a>")
                 );
                 return true;
             }

--- a/launcher/minecraft/auth/steps/XboxAuthorizationStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxAuthorizationStep.cpp
@@ -141,7 +141,7 @@ bool XboxAuthorizationStep::processSTSError(
                 emit finished(
                     AccountTaskState::STATE_FAILED_SOFT,
                     tr("This is not an adult Microsoft account and it is not linked to a family.\n\nPlease set up the account according to %1.")
-                        .arg("<a href=\"https://help.minecraft.net/hc/en-us/articles/4403181904525\">help.minecraft.net</a>")
+                        .arg(tr("<a href=\"https://help.minecraft.net/hc/en-us/articles/4403181904525\">help.minecraft.net</a>"))
                 );
                 return true;
             }

--- a/launcher/minecraft/auth/steps/XboxUserStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxUserStep.cpp
@@ -53,14 +53,14 @@ void XboxUserStep::onRequestDone(
 
     if (error != QNetworkReply::NoError) {
         qWarning() << "Reply error:" << error;
-        emit finished(AccountTaskState::STATE_FAILED_SOFT, tr("XBox user authentication failed."));
+        emit finished(AccountTaskState::STATE_FAILED_SOFT, tr("Xbox user authentication failed."));
         return;
     }
 
     Katabasis::Token temp;
     if(!Parsers::parseXTokenResponse(data, temp, "UToken")) {
         qWarning() << "Could not parse user authentication response...";
-        emit finished(AccountTaskState::STATE_FAILED_SOFT, tr("XBox user authentication response could not be understood."));
+        emit finished(AccountTaskState::STATE_FAILED_SOFT, tr("Unexpected Xbox user authentication response."));
         return;
     }
     m_data->userToken = temp;

--- a/launcher/minecraft/launch/DirectJavaLaunch.cpp
+++ b/launcher/minecraft/launch/DirectJavaLaunch.cpp
@@ -88,7 +88,7 @@ void DirectJavaLaunch::on_state(LoggedProcess::State state)
         case LoggedProcess::FailedToStart:
         {
             //: Error message displayed if instance can't start
-            const char *reason = QT_TR_NOOP("Could not launch minecraft!");
+            const char *reason = QT_TR_NOOP("Could not launch Minecraft!");
             emit logLine(reason, MessageLevel::Fatal);
             emitFailed(tr(reason));
             return;

--- a/launcher/minecraft/launch/VerifyJavaInstall.cpp
+++ b/launcher/minecraft/launch/VerifyJavaInstall.cpp
@@ -30,18 +30,18 @@ void VerifyJavaInstall::executeTask() {
     // Java 16 requirement
     else if (minecraftComponent->getReleaseDateTime() >= g_VersionFilterData.java16BeginsDate) {
         if (javaVersion.major() < 16) {
-            emit logLine("Minecraft 21w19a and above require the use of Java 16",
+            emit logLine("Minecraft 21w19a (1.17) and above require the use of Java 16",
                          MessageLevel::Fatal);
-            emitFailed(tr("Minecraft 21w19a and above require the use of Java 16"));
+            emitFailed(tr("Minecraft 21w19a (1.17) and above require the use of Java 16"));
             return;
         }
     }
     // Java 8 requirement
     else if (minecraftComponent->getReleaseDateTime() >= g_VersionFilterData.java8BeginsDate) {
         if (javaVersion.major() < 8) {
-            emit logLine("Minecraft 17w13a and above require the use of Java 8",
+            emit logLine("Minecraft 17w13a (1.12) and above require the use of Java 8",
                          MessageLevel::Fatal);
-            emitFailed(tr("Minecraft 17w13a and above require the use of Java 8"));
+            emitFailed(tr("Minecraft 17w13a (1.12) and above require the use of Java 8"));
             return;
         }
     }

--- a/launcher/minecraft/update/FMLLibrariesTask.cpp
+++ b/launcher/minecraft/update/FMLLibrariesTask.cpp
@@ -116,7 +116,7 @@ void FMLLibrariesTask::fmllibsFailed(QString reason)
 {
     QStringList failed = downloadJob->getFailedFiles();
     QString failed_all = failed.join("\n");
-    emitFailed(tr("Failed to download the following files:\n%1\n\nReason:%2\nPlease try again.").arg(failed_all, reason));
+    emitFailed(tr("Failed to download the following files:\n%1\n\nReason: %2\nPlease try again.").arg(failed_all, reason));
 }
 
 bool FMLLibrariesTask::abort()

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
@@ -91,7 +91,7 @@ void PackInstallTask::onDownloadSucceeded()
     }
     catch (const JSONValidationError &e)
     {
-        emitFailed(tr("Could not understand pack manifest:\n") + e.cause());
+        emitFailed(tr("Could not parse the pack manifest:\n") + e.cause());
         return;
     }
     m_version = version;
@@ -471,7 +471,7 @@ void PackInstallTask::extractConfigs()
     QuaZip packZip(archivePath);
     if(!packZip.open(QuaZip::mdUnzip))
     {
-        emitFailed(tr("Failed to open pack configs %1!").arg(archivePath));
+        emitFailed(tr("Failed to open the pack configs archive in %1").arg(archivePath));
         return;
     }
 

--- a/launcher/modplatform/modpacksch/FTBPackInstallTask.cpp
+++ b/launcher/modplatform/modpacksch/FTBPackInstallTask.cpp
@@ -94,7 +94,7 @@ void PackInstallTask::onDownloadSucceeded()
     }
     catch (const JSONValidationError &e)
     {
-        emitFailed(tr("Could not understand pack manifest:\n") + e.cause());
+        emitFailed(tr("Could not parse the pack manifest:\n") + e.cause());
         return;
     }
     m_version = version;

--- a/launcher/modplatform/technic/TechnicPackProcessor.cpp
+++ b/launcher/modplatform/technic/TechnicPackProcessor.cpp
@@ -90,7 +90,8 @@ void Technic::TechnicPackProcessor::run(SettingsObjectPtr globalSettings, const 
         else
         {
             if (minecraftVersion.isEmpty())
-                emit failed(tr("Could not find \"version.json\" inside \"bin/modpack.jar\", but minecraft version is unknown"));
+                emit failed(tr("Could not find \"version.json\" inside \"bin/modpack.jar\", "
+                               "the Minecraft version cannot be automatically determined"));
             components->setComponentVersion("net.minecraft", minecraftVersion, true);
             components->installJarMods({modpackJar});
 
@@ -145,7 +146,7 @@ void Technic::TechnicPackProcessor::run(SettingsObjectPtr globalSettings, const 
     else
     {
         // This is the "Vanilla" modpack, excluded by the search code
-        emit failed(tr("Unable to find a \"version.json\"!"));
+        emit failed(tr("Unable to find \"version.json\"!"));
         return;
     }
 
@@ -199,7 +200,7 @@ void Technic::TechnicPackProcessor::run(SettingsObjectPtr globalSettings, const 
     }
     catch (const JSONValidationError &e)
     {
-        emit failed(tr("Could not understand \"version.json\":\n") + e.cause());
+        emit failed(tr("Could not parse the file \"version.json\":\n") + e.cause());
         return;
     }
 

--- a/launcher/modplatform/technic/TechnicPackProcessor.cpp
+++ b/launcher/modplatform/technic/TechnicPackProcessor.cpp
@@ -146,7 +146,7 @@ void Technic::TechnicPackProcessor::run(SettingsObjectPtr globalSettings, const 
     else
     {
         // This is the "Vanilla" modpack, excluded by the search code
-        emit failed(tr("Unable to find \"version.json\"!"));
+        emit failed(tr("Unable to find the file \"version.json\"!"));
         return;
     }
 
@@ -159,7 +159,7 @@ void Technic::TechnicPackProcessor::run(SettingsObjectPtr globalSettings, const 
         {
             if (fmlMinecraftVersion.isEmpty())
             {
-                emit failed(tr("Could not understand \"version.json\":\ninheritsFrom is missing"));
+                emit failed(tr("Could not parse the file \"version.json\":\ninheritsFrom is missing"));
                 return;
             }
             minecraftVersion = fmlMinecraftVersion;

--- a/launcher/ui/InstanceWindow.cpp
+++ b/launcher/ui/InstanceWindow.cpp
@@ -37,7 +37,7 @@ InstanceWindow::InstanceWindow(InstancePtr instance, QWidget *parent)
     setAttribute(Qt::WA_DeleteOnClose);
 
     auto icon = APPLICATION->icons()->getIcon(m_instance->iconKey());
-    QString windowTitle = tr("Console window for ") + m_instance->name();
+    QString windowTitle = tr("Console window for %1").arg(m_instance->name());
 
     // Set window properties
     {

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -350,7 +350,7 @@ public:
             actionDISCORD->setObjectName(QStringLiteral("actionDISCORD"));
             actionDISCORD->setIcon(APPLICATION->getThemedIcon("discord"));
             actionDISCORD.setTextId(QT_TRANSLATE_NOOP("MainWindow", "Discord"));
-            actionDISCORD.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "Open %1 discord voice chat."));
+            actionDISCORD.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "Open %1 Discord chat."));
             all_actions.append(&actionDISCORD);
             helpMenu->addAction(actionDISCORD);
         }

--- a/launcher/ui/dialogs/ProfileSelectDialog.ui
+++ b/launcher/ui/dialogs/ProfileSelectDialog.ui
@@ -35,14 +35,14 @@
      <item>
       <widget class="QCheckBox" name="globalDefaultCheck">
        <property name="text">
-        <string>Use as default?</string>
+        <string>Use as default</string>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QCheckBox" name="instDefaultCheck">
        <property name="text">
-        <string>Use as default for this instance only?</string>
+        <string>Use as default for this instance only</string>
        </property>
       </widget>
      </item>

--- a/launcher/ui/dialogs/UpdateDialog.cpp
+++ b/launcher/ui/dialogs/UpdateDialog.cpp
@@ -133,12 +133,12 @@ QString reprocessCommits(QByteArray json)
             result += QObject::tr("<p>The update removes %1 commits and adds the following %2:</p>").arg(commit_behind).arg(commit_ahead);
             print_commits();
         }
-        result += QObject::tr("<p>You can <a href=\"%1\">look at the changes on github</a>.</p>").arg(diff_url);
+        result += QObject::tr("<p>You can <a href=\"%1\">look at the changes on GitHub</a>.</p>").arg(diff_url);
         return result;
     }
     catch (const JSONValidationError &e)
     {
-        qWarning() << "Got an unparseable commit log from github:" << e.what();
+        qWarning() << "Got an unparseable commit log from GitHub:" << e.what();
         qDebug() << json;
     }
     return QString();

--- a/launcher/ui/pages/global/AccountListPage.cpp
+++ b/launcher/ui/pages/global/AccountListPage.cpp
@@ -45,7 +45,7 @@ AccountListPage::AccountListPage(QWidget *parent)
     ui->setupUi(this);
     ui->listView->setEmptyString(tr(
         "Welcome!\n"
-        "If you're new here, you can click the \"Add\" button to add your Mojang or Minecraft account."
+        "Click the \"Add\" button to add a Mojang or Minecraft account."
     ));
     ui->listView->setEmptyMode(VersionListView::String);
     ui->listView->setContextMenuPolicy(Qt::CustomContextMenu);

--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -112,13 +112,10 @@ void LauncherPage::on_instDirBrowseBtn_clicked()
         if (FS::checkProblemticPathJava(QDir(cooked_dir)))
         {
             QMessageBox warning;
-            warning.setText(tr("You're trying to specify an instance folder which\'s path "
-                               "contains at least one \'!\'. "
-                               "Java is known to cause problems if that is the case, your "
-                               "instances (probably) won't start!"));
-            warning.setInformativeText(
-                tr("Do you really want to use this path? "
-                   "Selecting \"No\" will close this and not alter your instance path."));
+            warning.setText(tr("The specified instance path contains the disallowed symbol: '!'. "
+                               "Java has problems with paths containing '!', it is unlikely that "
+                               "the instance will be able to start."));
+            warning.setInformativeText(tr("Continue using the specified path?"));
             warning.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
             int result = warning.exec();
             if (result == QMessageBox::Yes)

--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -364,21 +364,21 @@
           <item>
            <widget class="QCheckBox" name="showConsoleCheck">
             <property name="text">
-             <string>Show console while the game is running?</string>
+             <string>Show console while the game is running</string>
             </property>
            </widget>
           </item>
           <item>
            <widget class="QCheckBox" name="autoCloseConsoleCheck">
             <property name="text">
-             <string>Automatically close console when the game quits?</string>
+             <string>Automatically close console when the game quits</string>
             </property>
            </widget>
           </item>
           <item>
            <widget class="QCheckBox" name="showConsoleErrorCheck">
             <property name="text">
-             <string>Show console when the game crashes?</string>
+             <string>Show console when the game crashes</string>
             </property>
            </widget>
           </item>
@@ -499,7 +499,7 @@
           <item>
            <widget class="QCheckBox" name="analyticsCheck">
             <property name="text">
-             <string>Send anonymous usage statistics?</string>
+             <string>Send anonymous usage statistics</string>
             </property>
            </widget>
           </item>

--- a/launcher/ui/pages/global/MinecraftPage.ui
+++ b/launcher/ui/pages/global/MinecraftPage.ui
@@ -51,7 +51,7 @@
           <item>
            <widget class="QCheckBox" name="maximizedCheckBox">
             <property name="text">
-             <string>Start Minecraft maximized?</string>
+             <string>Start Minecraft maximized</string>
             </property>
            </widget>
           </item>

--- a/launcher/ui/pages/global/PasteEEPage.ui
+++ b/launcher/ui/pages/global/PasteEEPage.ui
@@ -52,7 +52,7 @@
           <item>
            <widget class="QRadioButton" name="customButton">
             <property name="text">
-             <string>&amp;Your own key - 12MB upload limit:</string>
+             <string>&amp;Personal key - 12MB upload limit:</string>
             </property>
             <attribute name="buttonGroup">
              <string notr="true">pasteButtonGroup</string>
@@ -65,7 +65,7 @@
              <enum>QLineEdit::Password</enum>
             </property>
             <property name="placeholderText">
-             <string>Paste your API key here!</string>
+             <string>Paste the personal API key here</string>
             </property>
            </widget>
           </item>

--- a/launcher/ui/pages/instance/InstanceSettingsPage.ui
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.ui
@@ -246,7 +246,7 @@
           <item>
            <widget class="QCheckBox" name="maximizedCheckBox">
             <property name="text">
-             <string>Start Minecraft maximized?</string>
+             <string>Start Minecraft maximized</string>
             </property>
            </widget>
           </item>

--- a/launcher/ui/pages/instance/ScreenshotsPage.cpp
+++ b/launcher/ui/pages/instance/ScreenshotsPage.cpp
@@ -339,7 +339,7 @@ void ScreenshotsPage::on_actionUpload_triggered()
             CustomMessageBox::selectable(
                     this,
                     tr("Upload finished"),
-                    tr("The <a href=\"%1\">link  to the uploaded screenshot</a> has been placed in your clipboard.")
+                    tr("The <a href=\"%1\">link to the uploaded screenshot</a> has been placed in your clipboard.")
                         .arg(link),
                     QMessageBox::Information
             )->exec();

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -423,7 +423,7 @@ void VersionPage::on_actionInstall_Forge_triggered()
     }
     VersionSelectDialog vselect(vlist.get(), tr("Select Forge version"), this);
     vselect.setExactFilter(BaseVersionList::ParentVersionRole, m_profile->getComponentVersion("net.minecraft"));
-    vselect.setEmptyString(tr("No Forge versions are currently available for Minecraft ") + m_profile->getComponentVersion("net.minecraft"));
+    vselect.setEmptyString(tr("No Forge versions are currently available for Minecraft %1").arg(m_profile->getComponentVersion("net.minecraft")));
     vselect.setEmptyErrorString(tr("Couldn't load or download the Forge version lists!"));
 
     auto currentVersion = m_profile->getComponentVersion("net.minecraftforge");

--- a/launcher/ui/pages/instance/WorldListPage.cpp
+++ b/launcher/ui/pages/instance/WorldListPage.cpp
@@ -156,7 +156,7 @@ void WorldListPage::on_actionRemove_triggered()
 
     auto result = QMessageBox::question(this,
                 tr("Are you sure?"),
-                tr("This will remove the selected world permenantly.\n"
+                tr("This will remove the selected world permanently.\n"
                     "The world will be gone forever (A LONG TIME).\n"
                     "\n"
                     "Do you want to continue?"));

--- a/launcher/ui/pages/modplatform/ImportPage.cpp
+++ b/launcher/ui/pages/modplatform/ImportPage.cpp
@@ -103,7 +103,7 @@ void ImportPage::setUrl(const QString& url)
 
 void ImportPage::on_modpackBtn_clicked()
 {
-    const QUrl url = QFileDialog::getOpenFileUrl(this, tr("Choose modpack"), modpackUrl(), tr("Zip (*.zip)"));
+    const QUrl url = QFileDialog::getOpenFileUrl(this, tr("Choose modpack"), modpackUrl(), tr("ZIP Archive (*.zip)"));
     if (url.isValid())
     {
         if (url.isLocalFile())

--- a/launcher/ui/pages/modplatform/flame/FlamePage.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.cpp
@@ -100,7 +100,7 @@ void FlamePage::onSelectionChanged(QModelIndex first, QModelIndex second)
         for(auto & author: current.authors) {
             authorStrs.push_back(authorToStr(author));
         }
-        text += "<br>" + tr(" by ") + authorStrs.join(", ");
+        text = tr("%1 by %2").arg(text + "<br>", authorStrs.join(", "));
     }
     text += "<br><br>";
 

--- a/launcher/ui/pages/modplatform/legacy_ftb/Page.cpp
+++ b/launcher/ui/pages/modplatform/legacy_ftb/Page.cpp
@@ -238,7 +238,7 @@ void Page::onPackSelectionChanged(Modpack* pack)
     ui->versionSelectionBox->clear();
     if(pack)
     {
-        currentModpackInfo->setHtml("Pack by <b>" + pack->author + "</b>" +
+        currentModpackInfo->setHtml(tr("Pack by %1").arg("<b>" + pack->author + "</b>") +
                                     "<br>Minecraft " + pack->mcVersion + "<br>" + "<br>" + pack->description + "<ul><li>" + pack->mods.replace(";", "</li><li>")
                                     + "</li></ul>");
         bool currentAdded = false;

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
@@ -184,7 +184,7 @@ void TechnicPage::metadataLoaded()
         text = "<a href=\"" + current.websiteUrl + "\">" + name + "</a>";
     if (!current.author.isEmpty()) {
         // This allows injecting HTML here
-        text += tr(" by ") + current.author;
+        text = tr("%1 by %2").arg(text, current.author);
     }
 
     ui->frame->setModText(text);

--- a/launcher/ui/setupwizard/AnalyticsWizardPage.cpp
+++ b/launcher/ui/setupwizard/AnalyticsWizardPage.cpp
@@ -55,9 +55,9 @@ void AnalyticsWizardPage::retranslate()
         "<li>Anonymized (partial) IP address.</li>"
         "<li>Launcher version.</li>"
         "<li>Operating system name, version and architecture.</li>"
-        "<li>CPU architecture (kernel architecture on linux).</li>"
+        "<li>CPU architecture (kernel architecture on Linux).</li>"
         "<li>Size of system memory.</li>"
         "<li>Java version, architecture and memory settings.</li></ul>"
-        "<p>If we change the tracked information, you will see this page again.</p></body></html>"));
+        "<p>If we change the tracked information, this page will be shown again.</p></body></html>"));
     checkBox->setText(tr("Enable Analytics"));
 }

--- a/launcher/ui/widgets/JavaSettingsWidget.cpp
+++ b/launcher/ui/widgets/JavaSettingsWidget.cpp
@@ -149,11 +149,10 @@ JavaSettingsWidget::ValidationStatus JavaSettingsWidget::validate()
             int button = CustomMessageBox::selectable(
                 this,
                 tr("No Java version selected"),
-                tr("You didn't select a Java version or selected something that doesn't work.\n"
-                    "%1 will not be able to start Minecraft.\n"
-                    "Do you wish to proceed without any Java?"
+                tr("%1 will not be able to start Minecraft, because a working Java version has not been selected.\n"
+                    "The Java version can be changed in the settings at any time.\n"
                     "\n\n"
-                    "You can change the Java version in the settings later.\n"
+                    "Proceed without Java?"
                 ).arg(BuildConfig.LAUNCHER_NAME),
                 QMessageBox::Warning,
                 QMessageBox::Yes | QMessageBox::No,

--- a/launcher/ui/widgets/MCModInfoFrame.cpp
+++ b/launcher/ui/widgets/MCModInfoFrame.cpp
@@ -41,7 +41,7 @@ void MCModInfoFrame::updateWithMod(Mod &m)
     else
         text = "<a href=\"" + m.homeurl() + "\">" + name + "</a>";
     if (!m.authors().isEmpty())
-        text += " by " + m.authors().join(", ");
+        text = tr("%1 by %2").arg(text, m.authors().join(", "));
 
     setModText(text);
 


### PR DESCRIPTION
While localizing the launcher to Polish, I have encountered some issues in the source strings

- Typos
- Casual language, referring to the user as "You"
- Wrong capitalization
- Arguments (`%1`) not being used
- Not being able to translate URLs (e.g. to change `/en-us/` to `/pl-pl/`)
- Question marks in checkbox labels

This PR fixes some of the strings I had issues with