### PR TITLE
NOISSUE Change Technic and FTB legacy layout to be more consistent

### DIFF
--- a/launcher/ui/pages/modplatform/legacy_ftb/Page.ui
+++ b/launcher/ui/pages/modplatform/legacy_ftb/Page.ui
@@ -25,7 +25,7 @@
         <widget class="QTreeView" name="publicPackList">
          <property name="maximumSize">
           <size>
-           <width>250</width>
+           <width>16777215</width>
            <height>16777215</height>
           </size>
          </property>
@@ -51,7 +51,7 @@
         <widget class="QTreeView" name="thirdPartyPackList">
          <property name="maximumSize">
           <size>
-           <width>250</width>
+           <width>16777215</width>
            <height>16777215</height>
           </size>
          </property>
@@ -71,7 +71,7 @@
         <widget class="QTreeView" name="privatePackList">
          <property name="maximumSize">
           <size>
-           <width>250</width>
+           <width>16777215</width>
            <height>16777215</height>
           </size>
          </property>
@@ -103,16 +103,6 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout_4">
-     <item row="0" column="1">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Version selected:</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="2">
       <widget class="QComboBox" name="versionSelectionBox"/>
      </item>
@@ -123,6 +113,16 @@
          <width>265</width>
          <height>0</height>
         </size>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Version selected:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
       </widget>
      </item>

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
@@ -12,10 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * -----
- *
- * This source and all future changes to it are subject to the Microsoft Permissive License (MS-PL).
- * Please see the COPYING.md file for more information.
  */
 
 #include "TechnicPage.h"

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 MultiMC Contributors
+/* Copyright 2013-2022 MultiMC Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -11,6 +11,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * -----
+ *
+ * This source and all future changes to it are subject to the Microsoft Permissive License (MS-PL).
+ * Please see the COPYING.md file for more information.
  */
 
 #include "TechnicPage.h"
@@ -187,8 +192,9 @@ void TechnicPage::metadataLoaded()
         text += tr(" by ") + current.author;
     }
 
-    ui->frame->setModText(text);
-    ui->frame->setModDescription(current.description);
+    text += "<br><br>";
+
+    ui->packDescription->setHtml(text + current.description);
     if (!current.isSolder)
     {
         dialog->setSuggestedPack(current.name, new Technic::SingleZipPackInstallTask(current.url, current.minecraftVersion));

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.ui
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.ui
@@ -44,51 +44,36 @@
     </widget>
    </item>
    <item>
-    <widget class="QListView" name="packView">
-     <property name="horizontalScrollBarPolicy">
-      <enum>Qt::ScrollBarAlwaysOff</enum>
+    <layout class="QGridLayout" name="gridLayout">
+     <property name="rightMargin">
+      <number>0</number>
      </property>
-     <property name="alternatingRowColors">
-      <bool>true</bool>
-     </property>
-     <property name="iconSize">
-      <size>
-       <width>48</width>
-       <height>48</height>
-      </size>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="MCModInfoFrame" name="frame">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-    </widget>
+     <item row="0" column="1">
+      <widget class="QTextBrowser" name="packDescription"/>
+     </item>
+     <item row="0" column="0">
+      <widget class="QListView" name="packView">
+       <property name="horizontalScrollBarPolicy">
+        <enum>Qt::ScrollBarAlwaysOff</enum>
+       </property>
+       <property name="alternatingRowColors">
+        <bool>true</bool>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>48</width>
+         <height>48</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>MCModInfoFrame</class>
-   <extends>QFrame</extends>
-   <header>ui/widgets/MCModInfoFrame.h</header>
-   <container>1</container>
-  </customwidget>
- </customwidgets>
  <tabstops>
   <tabstop>searchEdit</tabstop>
   <tabstop>searchButton</tabstop>
-  <tabstop>packView</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
This PR changes the layout of Technic and FTB legacy import screen to be more consistent with other import screens.
<details>
  <summary>Images</summary>
 <table>
  <tr>
    <th>Platform</th>
    <th>Current</th>
    <th>Updated</th>
  </tr>
  <tr>
    <td>Legacy FTB</td>
    <td><img src="https://user-images.githubusercontent.com/34899572/154848893-14ff5985-1c50-4ea5-8298-4c0b78bdb787.png" alt="mmc-fl-old"></td>
    <td><img src="https://user-images.githubusercontent.com/34899572/154848897-31a4ae78-9373-4a17-ae0d-13b1095078e9.png" alt="mmc-fl"></td>
  </tr>
  <tr>
    <td>Technic</td>
    <td><img src="https://user-images.githubusercontent.com/34899572/154848900-d54df12c-7593-48db-bcf4-5d63b453ca39.png" alt="mmc-t-old"></td>
    <td><img src="https://user-images.githubusercontent.com/34899572/154848903-ca376e73-e141-45a9-ae9e-5f43cbc9e531.png" alt="mmc-t"></td>
  </tr>
</table> 

</details>

