### PR TITLE
Microsoft account string add

### DIFF
--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -55,7 +55,7 @@ void LaunchController::decideAccount()
         auto reply = CustomMessageBox::selectable(
             m_parentWidget,
             tr("No Accounts"),
-            tr("In order to play Minecraft, you must have at least one Mojang or Minecraft "
+            tr("In order to play Minecraft, you must have at least one Mojang or Microsoft "
                "account logged in."
                "Would you like to open the account manager to add an account now?"),
             QMessageBox::Information,


### PR DESCRIPTION
Since almost all of us are migrating our accounts to Microsoft accounts this would make more sense. And Minecraft account = offline account ig? There is prob way more microsoft account users then "cracked" account users using MultiMC.