### PR TITLE
NOISSUE Add microphone entitlement for macOS build

### DIFF
--- a/cmake/MacOSXBundleInfo.plist.in
+++ b/cmake/MacOSXBundleInfo.plist.in
@@ -36,5 +36,7 @@
     <true/>
     <key>NSHumanReadableCopyright</key>
     <string>${MACOSX_BUNDLE_COPYRIGHT}</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>MultiMC does not need access to your microphone for itself. Likely it's requesting it on behalf of a Minecraft mod you installed, which needs to access your microphone in order to function properly.</string>
 </dict>
 </plist>


### PR DESCRIPTION
Added the `NSMicrophoneUsageDescription` entitlement key, along with an explanation message for this entitlement.