### PR TITLE
NOISSUE Support installing CurseForge packs through modpacks.ch

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -519,6 +519,8 @@ set(MODPACKSCH_SOURCES
     modplatform/modpacksch/FTBPackInstallTask.cpp
     modplatform/modpacksch/FTBPackManifest.h
     modplatform/modpacksch/FTBPackManifest.cpp
+    modplatform/modpacksch/MCHPackType.h
+    modplatform/modpacksch/MCHPackType.cpp
 )
 
 set(TECHNIC_SOURCES

--- a/launcher/modplatform/modpacksch/FTBPackInstallTask.cpp
+++ b/launcher/modplatform/modpacksch/FTBPackInstallTask.cpp
@@ -85,7 +85,7 @@ void PackInstallTask::onDownloadSucceeded()
     QJsonParseError parse_error {};
     QJsonDocument doc = QJsonDocument::fromJson(response, &parse_error);
     if(parse_error.error != QJsonParseError::NoError) {
-        qWarning() << "Error while parsing JSON response from FTB at " << parse_error.offset << " reason: " << parse_error.errorString();
+        qWarning() << "Error while parsing JSON response from ModpacksCH at " << parse_error.offset << " reason: " << parse_error.errorString();
         qWarning() << response;
         return;
     }

--- a/launcher/modplatform/modpacksch/FTBPackInstallTask.h
+++ b/launcher/modplatform/modpacksch/FTBPackInstallTask.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "FTBPackManifest.h"
+#include "MCHPackType.h"
 
 #include "InstanceTask.h"
 #include "net/NetJob.h"
@@ -29,7 +30,7 @@ class PackInstallTask : public InstanceTask
     Q_OBJECT
 
 public:
-    explicit PackInstallTask(Modpack pack, QString version);
+    explicit PackInstallTask(Modpack pack, QString version, PackType type = PackType::ModpacksCH);
     virtual ~PackInstallTask(){}
 
     bool canAbort() const override { return true; }
@@ -55,6 +56,8 @@ private:
     Modpack m_pack;
     QString m_version_name;
     Version m_version;
+
+    PackType m_pack_type;
 
     QMap<QString, VersionFile> filesToExtract;
     QMap<QString, QString> filesToCopy;

--- a/launcher/modplatform/modpacksch/FTBPackInstallTask.h
+++ b/launcher/modplatform/modpacksch/FTBPackInstallTask.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Jamie Mansfield <jmansfield@cadixdev.org>
+ * Copyright 2020-2022 Jamie Mansfield <jmansfield@cadixdev.org>
  * Copyright 2020-2021 Petr Mrazek <peterix@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,6 +56,7 @@ private:
     QString m_version_name;
     Version m_version;
 
+    QMap<QString, VersionFile> filesToExtract;
     QMap<QString, QString> filesToCopy;
 
 };

--- a/launcher/modplatform/modpacksch/FTBPackManifest.cpp
+++ b/launcher/modplatform/modpacksch/FTBPackManifest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Jamie Mansfield <jmansfield@cadixdev.org>
+ * Copyright 2020-2022 Jamie Mansfield <jmansfield@cadixdev.org>
  * Copyright 2020-2021 Petr Mrazek <peterix@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -60,8 +60,12 @@ static void loadVersionInfo(ModpacksCH::VersionInfo & v, QJsonObject & obj)
     v.name = Json::requireString(obj, "name");
     v.type = Json::requireString(obj, "type");
     v.updated = Json::requireInteger(obj, "updated");
-    auto specs = Json::requireObject(obj, "specs");
-    loadSpecs(v.specs, specs);
+
+    // CurseForge packs don't have specs.
+    if (obj.contains("specs")) {
+        auto specs = Json::requireObject(obj, "specs");
+        loadSpecs(v.specs, specs);
+    }
 }
 
 void ModpacksCH::loadModpack(ModpacksCH::Modpack & m, QJsonObject & obj)
@@ -126,7 +130,19 @@ static void loadVersionFile(ModpacksCH::VersionFile & a, QJsonObject & obj)
     a.type = Json::requireString(obj, "type");
     a.path = Json::requireString(obj, "path");
     a.name = Json::requireString(obj, "name");
-    a.version = Json::requireString(obj, "version");
+
+    // This will be an integer with CurseForge packs.
+    auto versionVal = obj.value("version");
+    if (versionVal.isString()) {
+        a.version = versionVal.toString();
+    }
+    else if (versionVal.isDouble()) {
+        a.version = QString(versionVal.toInt());
+    }
+    else {
+        throw Json::JsonException("'version' is not a string or integer");
+    }
+
     a.url = Json::requireString(obj, "url");
     a.sha1 = Json::requireString(obj, "sha1");
     a.size = Json::requireInteger(obj, "size");
@@ -146,8 +162,13 @@ void ModpacksCH::loadVersion(ModpacksCH::Version & m, QJsonObject & obj)
     m.plays = Json::requireInteger(obj, "plays");
     m.updated = Json::requireInteger(obj, "updated");
     m.refreshed = Json::requireInteger(obj, "refreshed");
-    auto specs = Json::requireObject(obj, "specs");
-    loadSpecs(m.specs, specs);
+
+    // CurseForge packs don't have specs.
+    if (obj.contains("specs")) {
+        auto specs = Json::requireObject(obj, "specs");
+        loadSpecs(m.specs, specs);
+    }
+
     auto targetArr = Json::requireArray(obj, "targets");
     for (QJsonValueRef targetRaw : targetArr)
     {

--- a/launcher/modplatform/modpacksch/MCHPackType.cpp
+++ b/launcher/modplatform/modpacksch/MCHPackType.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Jamie Mansfield <jmansfield@cadixdev.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MCHPackType.h"
+
+#include <QString>
+
+namespace ModpacksCH {
+
+QString getRealmForPackType(PackType type)
+{
+    switch (type) {
+    case PackType::ModpacksCH:
+        return "modpack";
+    case PackType::CurseForge:
+        return "curseforge";
+    }
+}
+
+}

--- a/launcher/modplatform/modpacksch/MCHPackType.h
+++ b/launcher/modplatform/modpacksch/MCHPackType.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Jamie Mansfield <jmansfield@cadixdev.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <QString>
+
+namespace ModpacksCH {
+
+enum class PackType {
+    ModpacksCH,
+    CurseForge,
+};
+
+QString getRealmForPackType(PackType type);
+
+}

--- a/launcher/ui/pages/modplatform/ftb/FtbListModel.cpp
+++ b/launcher/ui/pages/modplatform/ftb/FtbListModel.cpp
@@ -122,10 +122,10 @@ void ListModel::requestFinished()
     jobPtr.reset();
     remainingPacks.clear();
 
-    QJsonParseError parse_error;
+    QJsonParseError parse_error {};
     QJsonDocument doc = QJsonDocument::fromJson(response, &parse_error);
     if(parse_error.error != QJsonParseError::NoError) {
-        qWarning() << "Error while parsing JSON response from FTB at " << parse_error.offset << " reason: " << parse_error.errorString();
+        qWarning() << "Error while parsing JSON response from ModpacksCH at " << parse_error.offset << " reason: " << parse_error.errorString();
         qWarning() << response;
         return;
     }
@@ -169,7 +169,7 @@ void ListModel::packRequestFinished()
     QJsonDocument doc = QJsonDocument::fromJson(response, &parse_error);
 
     if(parse_error.error != QJsonParseError::NoError) {
-        qWarning() << "Error while parsing JSON response from FTB at " << parse_error.offset << " reason: " << parse_error.errorString();
+        qWarning() << "Error while parsing JSON response from ModpacksCH at " << parse_error.offset << " reason: " << parse_error.errorString();
         qWarning() << response;
         return;
     }
@@ -184,7 +184,7 @@ void ListModel::packRequestFinished()
     catch (const JSONValidationError &e)
     {
         qDebug() << QString::fromUtf8(response);
-        qWarning() << "Error while reading pack manifest from FTB: " << e.cause();
+        qWarning() << "Error while reading pack manifest from ModpacksCH: " << e.cause();
         return;
     }
 
@@ -192,7 +192,7 @@ void ListModel::packRequestFinished()
     // ignore those "dud" packs.
     if (pack.versions.empty())
     {
-        qWarning() << "FTB Pack " << pack.id << " ignored. reason: lacking any versions";
+        qWarning() << "ModpacksCH Pack " << pack.id << " ignored. reason: lacking any versions";
     }
     else
     {
@@ -270,7 +270,7 @@ void ListModel::requestLogo(QString logo, QString url)
 
     bool stale = entry->isStale();
 
-    NetJob *job = new NetJob(QString("FTB Icon Download %1").arg(logo), APPLICATION->network());
+    auto *job = new NetJob(QString("ModpacksCH Icon Download %1").arg(logo), APPLICATION->network());
     job->addNetAction(Net::Download::makeCached(QUrl(url), entry));
 
     auto fullPath = entry->getFullPath();


### PR DESCRIPTION
This makes the neccasery changes to the modpacks.ch pack installation code to supporting installing CurseForge packs thorugh the platform, but doesn't make any of the changes to the GUI to support doing this.