### PR TITLE
NOISSUE Match Vanilla launcher for launch arguments

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -444,9 +444,8 @@ QStringList MinecraftInstance::processMinecraftArgs(
         }
     }
 
-    // blatant self-promotion.
-    token_mapping["profile_name"] = token_mapping["version_name"] = "MultiMC5";
-
+    token_mapping["profile_name"] = name();
+    token_mapping["version_name"] = profile->getMinecraftVersion();
     token_mapping["version_type"] = profile->getMinecraftVersionType();
 
     QString absRootDir = QDir(gameRoot()).absolutePath();


### PR DESCRIPTION
I'm not sure why this non-standard behaviour was present in the first place.

---

The commit(s) contained within this pull request have been cherry-picked from my own private fork of MultiMC from circa September 2021.

**For the benefit of XXX and MultiMC**: I only do development on a XXX or MultiMC workspace to resolve merge-conflicts, and to get changes building. No commits are ever cherry-picked onto my fork from a XXX or MultiMC workspace - nor between the two in either direction.