### PR TITLE
NOISSUE Apply the Minecraft version correctly

### DIFF
--- a/launcher/minecraft/VersionFile.cpp
+++ b/launcher/minecraft/VersionFile.cpp
@@ -20,7 +20,7 @@ void VersionFile::applyTo(LaunchProfile *profile)
     // Only real Minecraft can set those. Don't let anything override them.
     if (isMinecraftVersion(uid))
     {
-        profile->applyMinecraftVersion(minecraftVersion);
+        profile->applyMinecraftVersion(version);
         profile->applyMinecraftVersionType(type);
         // HACK: ignore assets from other version files than Minecraft
         // workaround for stupid assets issue caused by amazon:


### PR DESCRIPTION
It was previously using a deprecated field.

---

The commit(s) contained within this pull request have been cherry-picked from my own private fork of MultiMC from circa September 2021.

**For the benefit of PolyMC**: My fork is prior to multiple licences covering the MultiMC codebase, and no longer pulls changes from MultiMC as a result of these developments.

**For the benefit of PolyMC and MultiMC**: I only do development on a PolyMC or MultiMC workspace to resolve merge-conflicts, and to get changes building. No commits are ever cherry-picked onto my fork from a PolyMC or MultiMC workspace - nor between the two in either direction.