### PR TITLE
NOISSUE Handle depends for main class and extra arguments for ATLauncher

### DIFF
--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
@@ -357,14 +357,16 @@ bool PackInstallTask::createLibrariesComponent(QString instanceRoot, std::shared
 
 bool PackInstallTask::createPackComponent(QString instanceRoot, std::shared_ptr<PackProfile> profile)
 {
-    if(m_version.mainClass.mainClass.isEmpty() && m_version.extraArguments.isEmpty()) {
+    if(m_version.mainClass.mainClass.isEmpty() && m_version.extraArguments.arguments.isEmpty()) {
         return true;
     }
 
     auto mainClass = m_version.mainClass.mainClass;
+    auto extraArguments = m_version.extraArguments.arguments;
 
     auto hasMainClassDepends = !m_version.mainClass.depends.isEmpty();
-    if (hasMainClassDepends) {
+    auto hasExtraArgumentsDepends = !m_version.extraArguments.depends.isEmpty();
+    if (hasMainClassDepends || hasExtraArgumentsDepends) {
         QSet<QString> mods;
         for (const auto& item : m_version.mods) {
             mods.insert(item.name);
@@ -373,6 +375,14 @@ bool PackInstallTask::createPackComponent(QString instanceRoot, std::shared_ptr<
         if (hasMainClassDepends && !mods.contains(m_version.mainClass.depends)) {
             mainClass = "";
         }
+
+        if (hasExtraArgumentsDepends && !mods.contains(m_version.extraArguments.depends)) {
+            extraArguments = "";
+        }
+    }
+
+    if (mainClass.isEmpty() && extraArguments.isEmpty()) {
+        return true;
     }
 
     auto uuid = QUuid::createUuid();
@@ -404,7 +414,7 @@ bool PackInstallTask::createPackComponent(QString instanceRoot, std::shared_ptr<
     }
 
     // Parse out tweakers
-    auto args = m_version.extraArguments.split(" ");
+    auto args = extraArguments.split(" ");
     QString previous;
     for(auto arg : args) {
         if(arg.startsWith("--tweakClass=") || previous == "--tweakClass") {

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
@@ -727,6 +727,17 @@ bool PackInstallTask::extractMods(
     for (auto iter = toCopy.begin(); iter != toCopy.end(); iter++) {
         auto &from = iter.key();
         auto &to = iter.value();
+
+        // If the file already exists, assume the mod is the correct copy - and remove
+        // the copy from the Configs.zip
+        QFileInfo fileInfo(to);
+        if (fileInfo.exists()) {
+            if (!QFile::remove(to)) {
+                qWarning() << "Failed to delete" << to;
+                return false;
+            }
+        }
+
         FS::copy fileCopyOperation(from, to);
         if(!fileCopyOperation()) {
             qWarning() << "Failed to copy" << from << "to" << to;

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Jamie Mansfield <jmansfield@cadixdev.org>
+ * Copyright 2020-2022 Jamie Mansfield <jmansfield@cadixdev.org>
  * Copyright 2021 Petr Mrazek <peterix@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -357,8 +357,22 @@ bool PackInstallTask::createLibrariesComponent(QString instanceRoot, std::shared
 
 bool PackInstallTask::createPackComponent(QString instanceRoot, std::shared_ptr<PackProfile> profile)
 {
-    if(m_version.mainClass == QString() && m_version.extraArguments == QString()) {
+    if(m_version.mainClass.mainClass.isEmpty() && m_version.extraArguments.isEmpty()) {
         return true;
+    }
+
+    auto mainClass = m_version.mainClass.mainClass;
+
+    auto hasMainClassDepends = !m_version.mainClass.depends.isEmpty();
+    if (hasMainClassDepends) {
+        QSet<QString> mods;
+        for (const auto& item : m_version.mods) {
+            mods.insert(item.name);
+        }
+
+        if (hasMainClassDepends && !mods.contains(m_version.mainClass.depends)) {
+            mainClass = "";
+        }
     }
 
     auto uuid = QUuid::createUuid();
@@ -385,8 +399,8 @@ bool PackInstallTask::createPackComponent(QString instanceRoot, std::shared_ptr<
 
     auto f = std::make_shared<VersionFile>();
     f->name = m_pack + " " + m_version_name;
-    if(m_version.mainClass != QString() && !mainClasses.contains(m_version.mainClass)) {
-        f->mainClass = m_version.mainClass;
+    if(!mainClass.isEmpty() && !mainClasses.contains(mainClass)) {
+        f->mainClass = mainClass;
     }
 
     // Parse out tweakers

--- a/launcher/modplatform/atlauncher/ATLPackManifest.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackManifest.cpp
@@ -191,6 +191,12 @@ static void loadVersionMainClass(ATLauncher::PackVersionMainClass & m, QJsonObje
     m.depends = Json::ensureString(obj, "depends", "");
 }
 
+static void loadVersionExtraArguments(ATLauncher::PackVersionExtraArguments & a, QJsonObject & obj)
+{
+    a.arguments = Json::ensureString(obj, "arguments", "");
+    a.depends = Json::ensureString(obj, "depends", "");
+}
+
 void ATLauncher::loadVersion(PackVersion & v, QJsonObject & obj)
 {
     v.version = Json::requireString(obj, "version");
@@ -204,7 +210,7 @@ void ATLauncher::loadVersion(PackVersion & v, QJsonObject & obj)
 
     if(obj.contains("extraArguments")) {
         auto arguments = Json::requireObject(obj, "extraArguments");
-        v.extraArguments = Json::ensureString(arguments, "arguments", "");
+        loadVersionExtraArguments(v.extraArguments, arguments);
     }
 
     if(obj.contains("loader")) {

--- a/launcher/modplatform/atlauncher/ATLPackManifest.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackManifest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 Jamie Mansfield <jmansfield@cadixdev.org>
+ * Copyright 2020-2022 Jamie Mansfield <jmansfield@cadixdev.org>
  * Copyright 2021 Petr Mrazek <peterix@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -185,6 +185,12 @@ static void loadVersionMod(ATLauncher::VersionMod & p, QJsonObject & obj) {
     p.effectively_hidden = p.hidden || p.library;
 }
 
+static void loadVersionMainClass(ATLauncher::PackVersionMainClass & m, QJsonObject & obj)
+{
+    m.mainClass = Json::ensureString(obj, "mainClass", "");
+    m.depends = Json::ensureString(obj, "depends", "");
+}
+
 void ATLauncher::loadVersion(PackVersion & v, QJsonObject & obj)
 {
     v.version = Json::requireString(obj, "version");
@@ -193,7 +199,7 @@ void ATLauncher::loadVersion(PackVersion & v, QJsonObject & obj)
 
     if(obj.contains("mainClass")) {
         auto main = Json::requireObject(obj, "mainClass");
-        v.mainClass = Json::ensureString(main, "mainClass", "");
+        loadVersionMainClass(v.mainClass, main);
     }
 
     if(obj.contains("extraArguments")) {

--- a/launcher/modplatform/atlauncher/ATLPackManifest.h
+++ b/launcher/modplatform/atlauncher/ATLPackManifest.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Jamie Mansfield <jmansfield@cadixdev.org>
+ * Copyright 2020-2022 Jamie Mansfield <jmansfield@cadixdev.org>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,12 +122,18 @@ struct VersionConfigs
     QString sha1;
 };
 
+struct PackVersionMainClass
+{
+    QString mainClass;
+    QString depends;
+};
+
 struct PackVersion
 {
     QString version;
     QString minecraft;
     bool noConfigs;
-    QString mainClass;
+    PackVersionMainClass mainClass;
     QString extraArguments;
 
     VersionLoader loader;

--- a/launcher/modplatform/atlauncher/ATLPackManifest.h
+++ b/launcher/modplatform/atlauncher/ATLPackManifest.h
@@ -128,13 +128,19 @@ struct PackVersionMainClass
     QString depends;
 };
 
+struct PackVersionExtraArguments
+{
+    QString arguments;
+    QString depends;
+};
+
 struct PackVersion
 {
     QString version;
     QString minecraft;
     bool noConfigs;
     PackVersionMainClass mainClass;
-    QString extraArguments;
+    PackVersionExtraArguments extraArguments;
 
     VersionLoader loader;
     QVector<VersionLibrary> libraries;


### PR DESCRIPTION
This fixes a bug with installing All The Forge 8 where the main class would erronously be set to LaunchWrapper.

This was a result of not handling `depends` on `mainClass` (see below for an example). Where the mod depended on was no longer present (mod loaders have much better support on ATLauncher now).

```json
    "mainClass": {
        "mainClass": "net.minecraft.launchwrapper.Launch",
        "depends": "Minecraft Forge"
    },
```

---

The commit(s) contained within this pull request have been cherry-picked from my own private fork of MultiMC from circa September 2021.

**For the benefit of PolyMC**: My fork is prior to multiple licences covering the MultiMC codebase, and no longer pulls changes from MultiMC as a result of these developments.

**For the benefit of PolyMC and MultiMC**: I only do development on a PolyMC or MultiMC workspace to resolve merge-conflicts, and to get changes building. No commits are ever cherry-picked onto my fork from a PolyMC or MultiMC workspace - nor between the two in either direction.