### PR TITLE
NOISSUE Enforce allowed domains in Modrinth packs

### DIFF
--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -314,7 +314,7 @@ void InstanceImportTask::processModrinth() {
                     throw JSONValidationError("Download URL for " + file.path + " is not a correctly formatted URL");
                 }
                 QString downloadDomain = file.download.host();
-                if (std::find(std::begin(Modrinth::allowedDownloadDomains), std::end(Modrinth::allowedDownloadDomains), downloadDomain) == std::end(Modrinth::allowedDownloadDomains))
+                if (!Modrinth::allowedDownloadDomains.contains(downloadDomain))
                 {
                     throw JSONValidationError("Download URL for " + file.path + " is not on an allowed domain as per the Modrinth pack format specification");
                 }

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -313,6 +313,11 @@ void InstanceImportTask::processModrinth() {
                 {
                     throw JSONValidationError("Download URL for " + file.path + " is not a correctly formatted URL");
                 }
+                QString downloadDomain = file.download.host();
+                if (std::find(std::begin(Modrinth::allowedDownloadDomains), std::end(Modrinth::allowedDownloadDomains), downloadDomain) == std::end(Modrinth::allowedDownloadDomains))
+                {
+                    throw JSONValidationError("Download URL for " + file.path + " is not on an allowed domain as per the Modrinth pack format specification");
+                }
                 files.push_back(file);
             }
 

--- a/launcher/modplatform/modrinth/ModrinthPackManifest.h
+++ b/launcher/modplatform/modrinth/ModrinthPackManifest.h
@@ -22,7 +22,7 @@
 
 namespace Modrinth {
 
-const QString allowedDownloadDomains[] = {
+const QStringList allowedDownloadDomains = {
     "cdn.modrinth.com",
     "github.com",
     "raw.githubusercontent.com",

--- a/launcher/modplatform/modrinth/ModrinthPackManifest.h
+++ b/launcher/modplatform/modrinth/ModrinthPackManifest.h
@@ -1,4 +1,4 @@
-/* Copyright 2022 kb1000
+/* Copyright 2022 kb1000, arthomnix
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,14 @@
 #include <QUrl>
 
 namespace Modrinth {
+
+const QString allowedDownloadDomains[] = {
+    "cdn.modrinth.com",
+    "github.com",
+    "raw.githubusercontent.com",
+    "gitlab.com"
+};
+
 struct File
 {
     QString path;
@@ -29,4 +37,5 @@ struct File
     // TODO: should this support multiple download URLs, like the JSON does?
     QUrl download;
 };
+
 }


### PR DESCRIPTION
Adds a check to make sure that download URLs in Modrinth packs are on an allowed domain as per the [Modrinth pack specification](https://docs.modrinth.com/docs/modpacks/format_definition/#downloads).

This will likely break a lot of current Modrinth packs as it does not include CurseForge CDN domains that were recently removed from the specification upon CurseForge's request. It may be advisable to delay merging until Modrinth has removed packs with CF download URLs from their website.