### PR TITLE
NOISSUE (Re-)implement the ability to create instance shortcuts

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -778,7 +778,8 @@ SET(LAUNCHER_SOURCES
     ui/dialogs/VersionSelectDialog.h
     ui/dialogs/SkinUploadDialog.cpp
     ui/dialogs/SkinUploadDialog.h
-
+    ui/dialogs/CreateShortcutDialog.cpp
+    ui/dialogs/CreateShortcutDialog.h
 
     # GUI - widgets
     ui/widgets/Common.cpp
@@ -876,6 +877,7 @@ qt5_wrap_ui(LAUNCHER_UI
     ui/dialogs/AboutDialog.ui
     ui/dialogs/LoginDialog.ui
     ui/dialogs/EditAccountDialog.ui
+    ui/dialogs/CreateShortcutDialog.ui
 )
 
 qt5_add_resources(LAUNCHER_RESOURCES

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -84,13 +84,12 @@
 #include "ui/dialogs/EditAccountDialog.h"
 #include "ui/dialogs/NotificationDialog.h"
 #include "ui/dialogs/CreateShortcutDialog.h"
-
 #include "ui/dialogs/ExportInstanceDialog.h"
+
 #include "UpdateController.h"
-
 #include "KonamiCode.h"
-#include "InstanceImportTask.h"
 
+#include "InstanceImportTask.h"
 #include "InstanceCopyTask.h"
 #include "MMCTime.h"
 

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -91,6 +91,7 @@
 
 #include "InstanceImportTask.h"
 #include "InstanceCopyTask.h"
+
 #include "MMCTime.h"
 
 namespace {

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -83,14 +83,15 @@
 #include "ui/dialogs/UpdateDialog.h"
 #include "ui/dialogs/EditAccountDialog.h"
 #include "ui/dialogs/NotificationDialog.h"
+#include "ui/dialogs/CreateShortcutDialog.h"
+
 #include "ui/dialogs/ExportInstanceDialog.h"
-
 #include "UpdateController.h"
+
 #include "KonamiCode.h"
-
 #include "InstanceImportTask.h"
-#include "InstanceCopyTask.h"
 
+#include "InstanceCopyTask.h"
 #include "MMCTime.h"
 
 namespace {
@@ -222,6 +223,9 @@ public:
     TranslatedAction actionLaunchInstanceOffline;
     TranslatedAction actionScreenshots;
     TranslatedAction actionExportInstance;
+#if defined(Q_OS_LINUX) // currently only implemented for linux; TODO: other OS implementations
+    TranslatedAction actionCreateShortcut;
+#endif
     QVector<TranslatedAction *> all_actions;
 
     LabeledToolButton *renameButton = nullptr;
@@ -593,6 +597,15 @@ public:
         instanceToolBar->addAction(actionViewSelectedInstFolder);
 
         instanceToolBar->addSeparator();
+
+#if defined(Q_OS_LINUX)
+        actionCreateShortcut = TranslatedAction(MainWindow);
+        actionCreateShortcut->setObjectName(QStringLiteral("actionCreateShortcut"));
+        actionCreateShortcut.setTextId(QT_TRANSLATE_NOOP("MainWindow", "Create Shortcut"));
+        actionCreateShortcut.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "Create a shortcut that launches the selected instance"));
+        all_actions.append(&actionCreateShortcut);
+        instanceToolBar->addAction(actionCreateShortcut);
+#endif
 
         actionExportInstance = TranslatedAction(MainWindow);
         actionExportInstance->setObjectName(QStringLiteral("actionExportInstance"));
@@ -1843,6 +1856,15 @@ void MainWindow::on_actionLaunchInstance_triggered()
         APPLICATION->launch(m_selectedInstance);
     }
 }
+
+#if defined(Q_OS_LINUX)
+void MainWindow::on_actionCreateShortcut_triggered() {
+    if (m_selectedInstance)
+    {
+        CreateShortcutDialog(this, m_selectedInstance).exec();
+    }
+}
+#endif
 
 void MainWindow::activateInstance(InstancePtr instance)
 {

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -223,9 +223,7 @@ public:
     TranslatedAction actionLaunchInstanceOffline;
     TranslatedAction actionScreenshots;
     TranslatedAction actionExportInstance;
-#if defined(Q_OS_LINUX) // currently only implemented for linux; TODO: other OS implementations
     TranslatedAction actionCreateShortcut;
-#endif
     QVector<TranslatedAction *> all_actions;
 
     LabeledToolButton *renameButton = nullptr;
@@ -598,14 +596,12 @@ public:
 
         instanceToolBar->addSeparator();
 
-#if defined(Q_OS_LINUX)
         actionCreateShortcut = TranslatedAction(MainWindow);
         actionCreateShortcut->setObjectName(QStringLiteral("actionCreateShortcut"));
         actionCreateShortcut.setTextId(QT_TRANSLATE_NOOP("MainWindow", "Create Shortcut"));
         actionCreateShortcut.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "Create a shortcut that launches the selected instance"));
         all_actions.append(&actionCreateShortcut);
         instanceToolBar->addAction(actionCreateShortcut);
-#endif
 
         actionExportInstance = TranslatedAction(MainWindow);
         actionExportInstance->setObjectName(QStringLiteral("actionExportInstance"));
@@ -1857,14 +1853,12 @@ void MainWindow::on_actionLaunchInstance_triggered()
     }
 }
 
-#if defined(Q_OS_LINUX)
 void MainWindow::on_actionCreateShortcut_triggered() {
     if (m_selectedInstance)
     {
         CreateShortcutDialog(this, m_selectedInstance).exec();
     }
 }
-#endif
 
 void MainWindow::activateInstance(InstancePtr instance)
 {

--- a/launcher/ui/MainWindow.h
+++ b/launcher/ui/MainWindow.h
@@ -141,9 +141,7 @@ private slots:
 
     void on_actionScreenshots_triggered();
 
-#if defined(Q_OS_LINUX)
     void on_actionCreateShortcut_triggered();
-#endif
 
     void taskEnd();
 

--- a/launcher/ui/MainWindow.h
+++ b/launcher/ui/MainWindow.h
@@ -141,6 +141,10 @@ private slots:
 
     void on_actionScreenshots_triggered();
 
+#if defined(Q_OS_LINUX)
+    void on_actionCreateShortcut_triggered();
+#endif
+
     void taskEnd();
 
     /**

--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -137,7 +137,7 @@ void CreateShortcutDialog::createShortcut()
         if (ui->createScriptCheckBox->isChecked())
         {
             shortcutText = "#!/bin/sh\n"
-                    + "cd " + QCoreApplication::applicationDirPath() + "\n"
+                    "cd " + QCoreApplication::applicationDirPath() + "\n"
                     + getLaunchCommand() + " &\n";
         } else
             // freedesktop.org desktop entry

--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -125,7 +125,9 @@ void CreateShortcutDialog::createShortcut()
         // Unix shell script
         if (ui->createScriptCheckBox->isChecked())
         {
-            shortcutText = "#!/bin/sh\n" + getLaunchCommand() + " &\n";
+            shortcutText = "#!/bin/sh\n"
+                    + "cd " + QCoreApplication::applicationDirPath() + "\n"
+                    + getLaunchCommand() + " &\n";
         } else
             // freedesktop.org desktop entry
         {
@@ -148,6 +150,7 @@ void CreateShortcutDialog::createShortcut()
 #ifdef Q_OS_WIN
         // Windows batch script implementation
         shortcutText = "@ECHO OFF\r\n"
+                       "CD " + QDir::toNativeSeparators(QCoreApplication::applicationDirPath()) + "\r\n"
                        "START /B " + getLaunchCommand() + "\r\n";
 #endif
         QFile shortcutFile(ui->shortcutPath->text());
@@ -170,6 +173,7 @@ void CreateShortcutDialog::createShortcut()
         }
         
         createWindowsLink(QDir::toNativeSeparators(QCoreApplication::applicationFilePath()).toStdString().c_str(),
+                          QDir::toNativeSeparators(QCoreApplication::applicationFilePath()).toStdString().c_str(),
                           getLaunchArgs().toStdString().c_str(),
                           ui->shortcutPath->text().toStdString().c_str(),
                           (m_instance->name() + " - " + BuildConfig.LAUNCHER_DISPLAYNAME).toStdString().c_str(),
@@ -180,7 +184,8 @@ void CreateShortcutDialog::createShortcut()
 }
 
 #ifdef Q_OS_WIN
-void CreateShortcutDialog::createWindowsLink(LPCSTR target, LPCSTR args, LPCSTR filename, LPCSTR desc, LPCSTR iconPath)
+void CreateShortcutDialog::createWindowsLink(LPCSTR target, LPCSTR workingDir, LPCSTR args, LPCSTR filename,
+                                             LPCSTR desc, LPCSTR iconPath)
 {
     HRESULT result;
     IShellLink *link;
@@ -192,6 +197,7 @@ void CreateShortcutDialog::createWindowsLink(LPCSTR target, LPCSTR args, LPCSTR 
         IPersistFile *file;
 
         link->SetPath(target);
+        link->SetWorkingDirectory(workingDir);
         link->SetArguments(args);
         link->SetDescription(desc);
         link->SetIconLocation(iconPath, 0);

--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -44,7 +44,7 @@ CreateShortcutDialog::CreateShortcutDialog(QWidget *parent, InstancePtr instance
     {
         MinecraftInstancePtr minecraftInstance = qobject_pointer_cast<MinecraftInstance>(m_instance);
         QString version = minecraftInstance->getPackProfile()->getComponentVersion("net.minecraft");
-        bool enableJoinServer = QRegExp(JOIN_SERVER_DISALLOWED_VERSIONS).exactMatch(version);
+        bool enableJoinServer = !QRegExp(JOIN_SERVER_DISALLOWED_VERSIONS).exactMatch(version);
         ui->joinServerCheckBox->setEnabled(enableJoinServer);
         ui->joinServer->setEnabled(enableJoinServer);
     }

--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -41,6 +41,8 @@ CreateShortcutDialog::CreateShortcutDialog(QWidget *parent, InstancePtr instance
         ui->profileComboBox->setCurrentText(accounts->defaultAccount()->profileName());
     }
 
+    // check if instance is affected by a bug causing it to crash when trying to join a server on launch
+    // TODO: implement this check in meta
     if (m_instance->typeName() == "Minecraft")
     {
         try
@@ -64,6 +66,7 @@ CreateShortcutDialog::CreateShortcutDialog(QWidget *parent, InstancePtr instance
         }
     }
 
+    // Macs don't have any concept of a desktop shortcut, so force-enable the option to generate a shell script instead
 #if defined(Q_OS_UNIX) && !defined(Q_OS_LINUX)
     ui->createScriptCheckBox->setEnabled(false);
     ui->createScriptCheckBox->setChecked(true);

--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -129,7 +129,7 @@ void CreateShortcutDialog::updateDialogState()
 
 QString CreateShortcutDialog::getLaunchCommand()
 {
-    return QDir::toNativeSeparators(QCoreApplication::applicationFilePath())
+    return "\"" + QDir::toNativeSeparators(QCoreApplication::applicationFilePath()) + "\""
         + getLaunchArgs();
 }
 
@@ -155,7 +155,7 @@ void CreateShortcutDialog::createShortcut()
         if (ui->createScriptCheckBox->isChecked())
         {
             shortcutText = "#!/bin/sh\n"
-                    "cd " + QCoreApplication::applicationDirPath() + "\n"
+                    "cd \"" + QCoreApplication::applicationDirPath() + "\"\n"
                     + getLaunchCommand() + " &\n";
         } else
             // freedesktop.org desktop entry
@@ -179,7 +179,7 @@ void CreateShortcutDialog::createShortcut()
 #ifdef Q_OS_WIN
         // Windows batch script implementation
         shortcutText = "@ECHO OFF\r\n"
-                       "CD " + QDir::toNativeSeparators(QCoreApplication::applicationDirPath()) + "\r\n"
+                       "CD \"" + QDir::toNativeSeparators(QCoreApplication::applicationDirPath()) + "\"\r\n"
                        "START /B " + getLaunchCommand() + "\r\n";
 #endif
         QFile shortcutFile(ui->shortcutPath->text());

--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -56,6 +56,7 @@ void CreateShortcutDialog::on_shortcutPathBrowse_clicked()
     fileDialog.setDefaultSuffix(linkExtension);
     fileDialog.setAcceptMode(QFileDialog::AcceptOpen);
     fileDialog.setFileMode(QFileDialog::AnyFile);
+    fileDialog.selectFile(m_instance->id() + "." + linkExtension);
     if (fileDialog.exec())
     {
         ui->shortcutPath->setText(fileDialog.selectedFiles().at(0));

--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -92,6 +92,10 @@ void CreateShortcutDialog::updateDialogState()
     ui->profileComboBox->setEnabled(ui->useProfileCheckBox->isChecked());
     ui->offlineUsernameCheckBox->setEnabled(ui->launchOfflineCheckBox->isChecked());
     ui->offlineUsername->setEnabled(ui->launchOfflineCheckBox->isChecked() && ui->offlineUsernameCheckBox->isChecked());
+    if (!ui->launchOfflineCheckBox->isChecked())
+    {
+        ui->offlineUsernameCheckBox->setChecked(false);
+    }
 }
 
 QString CreateShortcutDialog::getLaunchCommand()
@@ -136,6 +140,7 @@ void CreateShortcutDialog::createShortcut()
                            "Type=Application\n"
                            "Name=" + m_instance->name() + " - " + BuildConfig.LAUNCHER_DISPLAYNAME + "\n"
                            + "Exec=" + getLaunchCommand() + "\n"
+                           + "Path=" + QCoreApplication::applicationDirPath() + "\n"
                            + "Icon=" + QCoreApplication::applicationDirPath() + "/icons/shortcut-icon.png\n";
 
         }

--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -47,8 +47,10 @@ CreateShortcutDialog::CreateShortcutDialog(QWidget *parent, InstancePtr instance
         {
             MinecraftInstancePtr minecraftInstance = qobject_pointer_cast<MinecraftInstance>(m_instance);
             minecraftInstance->getPackProfile()->reload(Net::Mode::Online);
-            QString version = minecraftInstance->getPackProfile()->getComponentVersion("net.minecraft");
-            bool enableJoinServer = !QRegExp(JOIN_SERVER_DISALLOWED_VERSIONS).exactMatch(version);
+            QDateTime versionDate = minecraftInstance->getPackProfile()->getComponent("net.minecraft")->getReleaseDateTime();
+            bool enableJoinServer = (versionDate < MC_145102_START)
+                    || (versionDate >= MC_145102_END && versionDate < MC_228828_START)
+                    || (versionDate >= MC_228828_END);
             ui->joinServerCheckBox->setEnabled(enableJoinServer);
             ui->joinServer->setEnabled(enableJoinServer);
         }

--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -99,6 +99,13 @@ void CreateShortcutDialog::createShortcut()
 {
     // Linux implementation using .desktop file
 #ifdef Q_OS_LINUX
+    // save the launcher icon to a file so we can use it in the shortcut
+    if (!QFileInfo::exists(QCoreApplication::applicationDirPath() + "/shortcut-icon.png"))
+    {
+        QPixmap iconPixmap = QIcon(":/logo.svg").pixmap(64, 64);
+        iconPixmap.save(QCoreApplication::applicationDirPath() + "/shortcut-icon.png");
+    }
+
     QFile desktopFile(ui->shortcutPath->text());
     if (desktopFile.open(QIODevice::WriteOnly))
     {
@@ -107,7 +114,8 @@ void CreateShortcutDialog::createShortcut()
         stream << "[Desktop Entry]" << endl
                     << "Type=Application" << endl
                     << "Name=" << m_instance->name() << " - " << BuildConfig.LAUNCHER_DISPLAYNAME << endl
-                    << "Exec=" << getLaunchCommand() << endl;
+                    << "Exec=" << getLaunchCommand() << endl
+                    << "Icon=" << QCoreApplication::applicationDirPath() << "/shortcut-icon.png" << endl;
         desktopFile.setPermissions(QFile::ReadOwner | QFile::ReadGroup | QFile::ReadOther
                                                 | QFile::WriteOwner | QFile::ExeOwner | QFile::ExeGroup);
         desktopFile.close();

--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -91,7 +91,7 @@ void CreateShortcutDialog::on_shortcutPathBrowse_clicked()
 #endif
     QFileDialog fileDialog(this, tr("Select shortcut path"), QStandardPaths::writableLocation(QStandardPaths::DesktopLocation));
     fileDialog.setDefaultSuffix(linkExtension);
-    fileDialog.setAcceptMode(QFileDialog::AcceptOpen);
+    fileDialog.setAcceptMode(QFileDialog::AcceptSave);
     fileDialog.setFileMode(QFileDialog::AnyFile);
     fileDialog.selectFile(m_instance->name() + " - " + BuildConfig.LAUNCHER_DISPLAYNAME + "." + linkExtension);
     if (fileDialog.exec())

--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -173,7 +173,7 @@ void CreateShortcutDialog::createShortcut()
         }
         
         createWindowsLink(QDir::toNativeSeparators(QCoreApplication::applicationFilePath()).toStdString().c_str(),
-                          QDir::toNativeSeparators(QCoreApplication::applicationFilePath()).toStdString().c_str(),
+                          QDir::toNativeSeparators(QCoreApplication::applicationDirPath()).toStdString().c_str(),
                           getLaunchArgs().toStdString().c_str(),
                           ui->shortcutPath->text().toStdString().c_str(),
                           (m_instance->name() + " - " + BuildConfig.LAUNCHER_DISPLAYNAME).toStdString().c_str(),

--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -155,7 +155,9 @@ void CreateShortcutDialog::createShortcut()
             shortcutFile.close();
         }
 #ifdef Q_OS_WIN
-    } else {
+    }
+    else
+    {
         if (!QFileInfo::exists(QCoreApplication::applicationDirPath() + "/icons/shortcut-icon.ico"))
         {
             QPixmap iconPixmap = QIcon(":/logo.svg").pixmap(64, 64);

--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2022 arthomnix
+ *
+ * This source is subject to the Microsoft Public License (MS-PL).
+ * Please see the COPYING.md file for more information.
+ */
+
+#include <fstream>
+#include <iostream>
+#include <QFileDialog>
+#include <BuildConfig.h>
+#include "CreateShortcutDialog.h"
+#include "ui_CreateShortcutDialog.h"
+#include "Application.h"
+#include "minecraft/auth/AccountList.h"
+#include "icons/IconList.h"
+
+CreateShortcutDialog::CreateShortcutDialog(QWidget *parent, InstancePtr instance)
+    :QDialog(parent), ui(new Ui::CreateShortcutDialog), m_instance(instance)
+{
+    ui->setupUi(this);
+
+    QStringList accountNameList;
+    auto accounts = APPLICATION->accounts();
+
+    for (int i = 0; i < accounts->count(); i++)
+    {
+        accountNameList.append(accounts->at(i)->profileName());
+    }
+
+    ui->profileComboBox->addItems(accountNameList);
+
+    if (accounts->defaultAccount())
+    {
+        ui->profileComboBox->setCurrentText(accounts->defaultAccount()->profileName());
+    }
+
+    updateDialogState();
+}
+
+CreateShortcutDialog::~CreateShortcutDialog()
+{
+    delete ui;
+}
+
+void CreateShortcutDialog::on_shortcutPathBrowse_clicked()
+{
+    QString linkExtension;
+#ifdef Q_OS_LINUX
+    linkExtension = "desktop";
+#endif
+#ifdef Q_OS_WIN
+    linkExtension = "lnk";
+#endif
+    QFileDialog fileDialog(this, tr("Select shortcut path"), QStandardPaths::writableLocation(QStandardPaths::DesktopLocation));
+    fileDialog.setDefaultSuffix(linkExtension);
+    fileDialog.setAcceptMode(QFileDialog::AcceptOpen);
+    fileDialog.setFileMode(QFileDialog::AnyFile);
+    if (fileDialog.exec())
+    {
+        ui->shortcutPath->setText(fileDialog.selectedFiles().at(0));
+    }
+    updateDialogState();
+}
+
+void CreateShortcutDialog::accept()
+{
+    createShortcut();
+    QDialog::accept();
+}
+
+
+void CreateShortcutDialog::updateDialogState()
+{
+
+    ui->buttonBox->button(QDialogButtonBox::StandardButton::Ok)->setEnabled(
+            !ui->shortcutPath->text().isEmpty()
+            && (!ui->joinServerCheckBox->isChecked() || !ui->joinServer->text().isEmpty())
+            && (!ui->offlineUsernameCheckBox->isChecked() || !ui->offlineUsername->text().isEmpty())
+            && (!ui->useProfileCheckBox->isChecked() || !ui->profileComboBox->currentText().isEmpty())
+    );
+    ui->joinServer->setEnabled(ui->joinServerCheckBox->isChecked());
+    ui->profileComboBox->setEnabled(ui->useProfileCheckBox->isChecked());
+    ui->offlineUsernameCheckBox->setEnabled(ui->launchOfflineCheckBox->isChecked());
+    ui->offlineUsername->setEnabled(ui->launchOfflineCheckBox->isChecked() && ui->offlineUsernameCheckBox->isChecked());
+}
+
+QString CreateShortcutDialog::getLaunchCommand()
+{
+    return QCoreApplication::applicationFilePath()
+        + " -l " + m_instance->id()
+        + (ui->joinServerCheckBox->isChecked() ? " -s " + ui->joinServer->text() : "")
+        + (ui->useProfileCheckBox->isChecked() ? " -a " + ui->profileComboBox->currentText() : "")
+        + (ui->launchOfflineCheckBox->isChecked() ? " -o" : "")
+        + (ui->offlineUsernameCheckBox->isChecked() ? " -n " + ui->offlineUsername->text() : "");
+}
+
+void CreateShortcutDialog::createShortcut()
+{
+    // Linux implementation using .desktop file
+#ifdef Q_OS_LINUX
+    QFile desktopFile(ui->shortcutPath->text());
+    if (desktopFile.open(QIODevice::WriteOnly))
+    {
+        QTextStream stream(&desktopFile);
+        qDebug() << m_instance->iconKey();
+        stream << "[Desktop Entry]" << endl
+                    << "Type=Application" << endl
+                    << "Name=" << m_instance->name() << " - " << BuildConfig.LAUNCHER_DISPLAYNAME << endl
+                    << "Exec=" << getLaunchCommand() << endl;
+        desktopFile.setPermissions(QFile::ReadOwner | QFile::ReadGroup | QFile::ReadOther
+                                                | QFile::WriteOwner | QFile::ExeOwner | QFile::ExeGroup);
+        desktopFile.close();
+    }
+#endif
+    // TODO: implementations for other operating systems
+}

--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -11,6 +11,8 @@
 #include "ui_CreateShortcutDialog.h"
 #include "Application.h"
 #include "minecraft/auth/AccountList.h"
+#include "minecraft/MinecraftInstance.h"
+#include "minecraft/PackProfile.h"
 #include "icons/IconList.h"
 
 #ifdef Q_OS_WIN
@@ -36,6 +38,15 @@ CreateShortcutDialog::CreateShortcutDialog(QWidget *parent, InstancePtr instance
     if (accounts->defaultAccount())
     {
         ui->profileComboBox->setCurrentText(accounts->defaultAccount()->profileName());
+    }
+
+    if (m_instance->typeName() == "Minecraft")
+    {
+        MinecraftInstancePtr minecraftInstance = qobject_pointer_cast<MinecraftInstance>(m_instance);
+        QString version = minecraftInstance->getPackProfile()->getComponentVersion("net.minecraft");
+        bool enableJoinServer = QRegExp(JOIN_SERVER_DISALLOWED_VERSIONS).exactMatch(version);
+        ui->joinServerCheckBox->setEnabled(enableJoinServer);
+        ui->joinServer->setEnabled(enableJoinServer);
     }
 
 #if defined(Q_OS_UNIX) && !defined(Q_OS_LINUX)

--- a/launcher/ui/dialogs/CreateShortcutDialog.h
+++ b/launcher/ui/dialogs/CreateShortcutDialog.h
@@ -11,6 +11,10 @@
 #include "minecraft/auth/MinecraftAccount.h"
 #include "BaseInstance.h"
 
+#ifdef Q_OS_WIN
+#include <windows.h>
+#endif
+
 namespace Ui
 {
     class CreateShortcutDialog;
@@ -35,6 +39,11 @@ private:
     InstancePtr m_instance;
 
     QString getLaunchCommand();
+    QString getLaunchArgs();
 
     void createShortcut();
+
+#ifdef Q_OS_WIN
+    void createWindowsLink(LPCSTR target, LPCSTR args, LPCSTR filename, LPCSTR desc, LPCSTR iconPath);
+#endif
 };

--- a/launcher/ui/dialogs/CreateShortcutDialog.h
+++ b/launcher/ui/dialogs/CreateShortcutDialog.h
@@ -44,6 +44,6 @@ private:
     void createShortcut();
 
 #ifdef Q_OS_WIN
-    void createWindowsLink(LPCSTR target, LPCSTR args, LPCSTR filename, LPCSTR desc, LPCSTR iconPath);
+    void createWindowsLink(LPCSTR target, LPCSTR workingDir, LPCSTR args, LPCSTR filename, LPCSTR desc, LPCSTR iconPath);
 #endif
 };

--- a/launcher/ui/dialogs/CreateShortcutDialog.h
+++ b/launcher/ui/dialogs/CreateShortcutDialog.h
@@ -10,26 +10,17 @@
 #include <QDialog>
 #include "minecraft/auth/MinecraftAccount.h"
 #include "BaseInstance.h"
+#include "minecraft/ParseUtils.h"
 
 #ifdef Q_OS_WIN
 #include <windows.h>
 #endif
 
-const QString JOIN_SERVER_DISALLOWED_VERSIONS(
-        "(19w0[89][a-z])"
-        "|(19w1[0-9][a-z])"
-        "|(1.14.?[1-4]?-pre[0-9])"
-        "|(1.14.?[1-4]?)"
-        "|(19w[34][0-9][a-z])"
-        "|(1.15.?[0-9]?-pre[0-9])"
-        "|(1.15.?[0-9]?)"
-        "|(20w[01][0-9][a-z])"
-        "|(20w20a)"
-        "|(21w[12][0-9][a-z])"
-        "|(1.17-pre[0-9])"
-        "|(1.17-rc[0-9])"
-        "|(1.17)"
-        );
+// Dates when the game was affected by bugs that crashed the game when using the option to join a server on startup
+const QDateTime MC_145102_START = timeFromS3Time("2019-02-20T14:56:58+00:00");
+const QDateTime MC_145102_END = timeFromS3Time("2020-05-14T08:16:26+00:00");
+const QDateTime MC_228828_START = timeFromS3Time("2021-03-10T15:24:38+00:00");
+const QDateTime MC_228828_END = timeFromS3Time("2021-06-18T12:24:40+00:00");
 
 namespace Ui
 {

--- a/launcher/ui/dialogs/CreateShortcutDialog.h
+++ b/launcher/ui/dialogs/CreateShortcutDialog.h
@@ -15,6 +15,22 @@
 #include <windows.h>
 #endif
 
+const QString JOIN_SERVER_DISALLOWED_VERSIONS(
+        "(19w0[89][a-z])"
+        "|(19w1[0-9][a-z])"
+        "|(1.14.?[1-4]?-pre[0-9])"
+        "|(1.14.?[1-4]?)"
+        "|(19w[34][0-9][a-z])"
+        "|(1.15.?[0-9]?-pre[0-9])"
+        "|(1.15.?[0-9]?)"
+        "|(20w[01][0-9][a-z])"
+        "|(20w20a)"
+        "|(21w[12][0-9][a-z])"
+        "|(1.17-pre[0-9])"
+        "|(1.17-rc[0-9])"
+        "|(1.17)"
+        );
+
 namespace Ui
 {
     class CreateShortcutDialog;

--- a/launcher/ui/dialogs/CreateShortcutDialog.h
+++ b/launcher/ui/dialogs/CreateShortcutDialog.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 arthomnix
+ *
+ * This source is subject to the Microsoft Public License (MS-PL).
+ * Please see the COPYING.md file for more information.
+ */
+
+#pragma once
+
+#include <QDialog>
+#include "minecraft/auth/MinecraftAccount.h"
+#include "BaseInstance.h"
+
+namespace Ui
+{
+    class CreateShortcutDialog;
+}
+
+class CreateShortcutDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit CreateShortcutDialog(QWidget *parent = nullptr, InstancePtr instance = nullptr);
+    ~CreateShortcutDialog() override;
+
+private
+slots:
+    void on_shortcutPathBrowse_clicked();
+    void updateDialogState();
+    void accept() override;
+
+private:
+    Ui::CreateShortcutDialog *ui;
+    InstancePtr m_instance;
+
+    QString getLaunchCommand();
+
+    void createShortcut();
+};

--- a/launcher/ui/dialogs/CreateShortcutDialog.ui
+++ b/launcher/ui/dialogs/CreateShortcutDialog.ui
@@ -1,0 +1,275 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2022 arthomnix
+
+ This source is subject to the Microsoft Public License (MS-PL).
+ Please see the COPYING.md file for more information.
+-->
+<ui version="4.0">
+ <class>CreateShortcutDialog</class>
+ <widget class="QDialog" name="CreateShortcutDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>796</width>
+    <height>230</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>796</width>
+    <height>230</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Create Shortcut</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetDefaultConstraint</enum>
+     </property>
+     <item row="1" column="0">
+      <widget class="QCheckBox" name="joinServerCheckBox">
+       <property name="text">
+        <string>Join server on launch:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="shortcutPathLabel">
+       <property name="text">
+        <string>Shortcut path:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="joinServer"/>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="shortcutPath"/>
+     </item>
+     <item row="3" column="0">
+      <widget class="QCheckBox" name="launchOfflineCheckBox">
+       <property name="text">
+        <string>Launch in offline mode</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QLineEdit" name="offlineUsername"/>
+     </item>
+     <item row="0" column="2">
+      <widget class="QPushButton" name="shortcutPathBrowse">
+       <property name="text">
+        <string>Browse</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QCheckBox" name="useProfileCheckBox">
+       <property name="text">
+        <string>Use specific profile:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QComboBox" name="profileComboBox"/>
+     </item>
+     <item row="4" column="0">
+      <widget class="QCheckBox" name="offlineUsernameCheckBox">
+       <property name="text">
+        <string>Set offline mode username:</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>CreateShortcutDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>397</x>
+     <y>207</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>397</x>
+     <y>114</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>CreateShortcutDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>397</x>
+     <y>207</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>397</x>
+     <y>114</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>joinServer</sender>
+   <signal>textChanged(QString)</signal>
+   <receiver>CreateShortcutDialog</receiver>
+   <slot>updateDialogState()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>471</x>
+     <y>61</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>397</x>
+     <y>114</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>joinServerCheckBox</sender>
+   <signal>stateChanged(int)</signal>
+   <receiver>CreateShortcutDialog</receiver>
+   <slot>updateDialogState()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>122</x>
+     <y>61</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>397</x>
+     <y>114</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>launchOfflineCheckBox</sender>
+   <signal>stateChanged(int)</signal>
+   <receiver>CreateShortcutDialog</receiver>
+   <slot>updateDialogState()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>122</x>
+     <y>130</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>397</x>
+     <y>114</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>offlineUsername</sender>
+   <signal>textChanged(QString)</signal>
+   <receiver>CreateShortcutDialog</receiver>
+   <slot>updateDialogState()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>471</x>
+     <y>162</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>397</x>
+     <y>114</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>offlineUsernameCheckBox</sender>
+   <signal>stateChanged(int)</signal>
+   <receiver>CreateShortcutDialog</receiver>
+   <slot>updateDialogState()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>122</x>
+     <y>162</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>397</x>
+     <y>114</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>profileComboBox</sender>
+   <signal>currentTextChanged(QString)</signal>
+   <receiver>CreateShortcutDialog</receiver>
+   <slot>updateDialogState()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>471</x>
+     <y>98</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>397</x>
+     <y>114</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>shortcutPath</sender>
+   <signal>textChanged(QString)</signal>
+   <receiver>CreateShortcutDialog</receiver>
+   <slot>updateDialogState()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>471</x>
+     <y>23</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>397</x>
+     <y>114</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>useProfileCheckBox</sender>
+   <signal>stateChanged(int)</signal>
+   <receiver>CreateShortcutDialog</receiver>
+   <slot>updateDialogState()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>122</x>
+     <y>98</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>397</x>
+     <y>114</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/launcher/ui/dialogs/CreateShortcutDialog.ui
+++ b/launcher/ui/dialogs/CreateShortcutDialog.ui
@@ -1,10 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
- Copyright 2022 arthomnix
-
- This source is subject to the Microsoft Public License (MS-PL).
- Please see the COPYING.md file for more information.
--->
 <ui version="4.0">
  <class>CreateShortcutDialog</class>
  <widget class="QDialog" name="CreateShortcutDialog">
@@ -13,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>796</width>
-    <height>230</height>
+    <height>232</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -31,10 +25,10 @@
      <property name="sizeConstraint">
       <enum>QLayout::SetDefaultConstraint</enum>
      </property>
-     <item row="1" column="0">
-      <widget class="QCheckBox" name="joinServerCheckBox">
+     <item row="3" column="0">
+      <widget class="QCheckBox" name="launchOfflineCheckBox">
        <property name="text">
-        <string>Join server on launch:</string>
+        <string>Launch in offline mode</string>
        </property>
       </widget>
      </item>
@@ -45,26 +39,33 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="joinServer"/>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLineEdit" name="shortcutPath"/>
-     </item>
-     <item row="3" column="0">
-      <widget class="QCheckBox" name="launchOfflineCheckBox">
-       <property name="text">
-        <string>Launch in offline mode</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QLineEdit" name="offlineUsername"/>
-     </item>
      <item row="0" column="2">
       <widget class="QPushButton" name="shortcutPathBrowse">
        <property name="text">
         <string>Browse</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="shortcutPath"/>
+     </item>
+     <item row="2" column="1">
+      <widget class="QComboBox" name="profileComboBox"/>
+     </item>
+     <item row="4" column="1">
+      <widget class="QLineEdit" name="offlineUsername"/>
+     </item>
+     <item row="4" column="0">
+      <widget class="QCheckBox" name="offlineUsernameCheckBox">
+       <property name="text">
+        <string>Set offline mode username:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QCheckBox" name="joinServerCheckBox">
+       <property name="text">
+        <string>Join server on launch:</string>
        </property>
       </widget>
      </item>
@@ -75,15 +76,8 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
-      <widget class="QComboBox" name="profileComboBox"/>
-     </item>
-     <item row="4" column="0">
-      <widget class="QCheckBox" name="offlineUsernameCheckBox">
-       <property name="text">
-        <string>Set offline mode username:</string>
-       </property>
-      </widget>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="joinServer"/>
      </item>
     </layout>
    </item>
@@ -101,11 +95,25 @@
     </spacer>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="bottomMargin">
+      <number>0</number>
      </property>
-    </widget>
+     <item>
+      <widget class="QCheckBox" name="createScriptCheckBox">
+       <property name="text">
+        <string>Create script instead of shortcut</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/launcher/ui/dialogs/CreateShortcutDialog.ui
+++ b/launcher/ui/dialogs/CreateShortcutDialog.ui
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2022 arthomnix
+ This source is subject to the Microsoft Public License (MS-PL).
+ Please see the COPYING.md file for more information.
+-->
 <ui version="4.0">
  <class>CreateShortcutDialog</class>
  <widget class="QDialog" name="CreateShortcutDialog">


### PR DESCRIPTION
Adds the ability to create a desktop shortcut to launch an instance, using MMC's command line arguments.
This was apparently a MMC4 feature that has been missing in MMC5 for 10 years.

~~This is currently WIP and only works on Linux, and is missing a few features such as setting an icon for the shortcut automatically.~~ Now works cross-platform and is ready for review