### PR TITLE
NOISSUE log file extension of mods to clear ambiguity

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -623,15 +623,15 @@ QStringList MinecraftInstance::verboseDescription(AuthSessionPtr session, Minecr
             {
                 if(mod.type() == Mod::MOD_FOLDER)
                 {
-                    out << u8"  [📁] " + mod.filename().completeBaseName() + " (folder)";
+                    out << u8"  [📁] " + mod.filename().fileName() + " (folder)";
                     continue;
                 }
 
                 if(mod.enabled()) {
-                    out << u8"  [✔️] " + mod.filename().completeBaseName();
+                    out << u8"  [✔️] " + mod.filename().fileName();
                 }
                 else {
-                    out << u8"  [❌] " + mod.filename().completeBaseName() + " (disabled)";
+                    out << u8"  [❌] " + mod.filename().fileName() + " (disabled)";
                 }
 
             }


### PR DESCRIPTION
- While troubleshooting an odd issue with someone on discord that ended up being browsers downloading mods with incorrect file extensions, I noticed that MultiMC did not log file extensions for the mods folder
- Logging this information will make it much easier to pick up on these kinds of mistakes
- How it looks:

![Y0708_233344](https://user-images.githubusercontent.com/30675315/178089983-256b3e50-6639-47b8-8eac-05b65b49dc37.png)
