### PR TITLE
GH-4812 Prefill instance name to allow making adjustments

### DIFF
--- a/launcher/ui/dialogs/NewInstanceDialog.cpp
+++ b/launcher/ui/dialogs/NewInstanceDialog.cpp
@@ -154,10 +154,10 @@ void NewInstanceDialog::setSuggestedPack(const QString& name, InstanceTask* task
     creationTask.reset(task);
 
     defaultInstName = name;
+    ui->instNameTextBox->setPlaceholderText(name);
 
     if (!instNameChanged)
     {
-        ui->instNameTextBox->setPlaceholderText(name);
         ui->instNameTextBox->setText(name);
     }
 

--- a/launcher/ui/dialogs/NewInstanceDialog.cpp
+++ b/launcher/ui/dialogs/NewInstanceDialog.cpp
@@ -151,6 +151,9 @@ void NewInstanceDialog::setSuggestedPack(const QString& name, InstanceTask* task
 {
     creationTask.reset(task);
     ui->instNameTextBox->setPlaceholderText(name);
+    ui->instNameTextBox->setText(name);
+    ui->instNameTextBox->selectAll();
+    ui->instNameTextBox->setFocus();
 
     if(!task)
     {

--- a/launcher/ui/dialogs/NewInstanceDialog.cpp
+++ b/launcher/ui/dialogs/NewInstanceDialog.cpp
@@ -103,6 +103,8 @@ NewInstanceDialog::NewInstanceDialog(const QString & initialGroup, const QString
         importPage->setUrl(url);
     }
 
+    connect(APPLICATION, &QApplication::focusChanged, this, &NewInstanceDialog::onFocusChanged);
+
     updateDialogState();
 
     restoreGeometry(QByteArray::fromBase64(APPLICATION->settings()->get("NewInstanceGeometry").toByteArray()));
@@ -150,10 +152,14 @@ NewInstanceDialog::~NewInstanceDialog()
 void NewInstanceDialog::setSuggestedPack(const QString& name, InstanceTask* task)
 {
     creationTask.reset(task);
-    ui->instNameTextBox->setPlaceholderText(name);
-    ui->instNameTextBox->setText(name);
-    ui->instNameTextBox->selectAll();
-    ui->instNameTextBox->setFocus();
+
+    defaultInstName = name;
+
+    if (!instNameChanged)
+    {
+        ui->instNameTextBox->setPlaceholderText(name);
+        ui->instNameTextBox->setText(name);
+    }
 
     if(!task)
     {
@@ -241,9 +247,27 @@ void NewInstanceDialog::on_iconButton_clicked()
     }
 }
 
+void NewInstanceDialog::on_resetNameButton_clicked()
+{
+    ui->instNameTextBox->setText(defaultInstName);
+    instNameChanged = false;
+}
+
 void NewInstanceDialog::on_instNameTextBox_textChanged(const QString &arg1)
 {
     updateDialogState();
+}
+
+void NewInstanceDialog::on_instNameTextBox_textEdited(const QString &text)
+{
+    instNameChanged = true;
+}
+
+void NewInstanceDialog::onFocusChanged(QWidget *, QWidget *newWidget)
+{
+    if (newWidget == ui->instNameTextBox && !instNameChanged) {
+        QTimer::singleShot(0, ui->instNameTextBox, &QLineEdit::selectAll);
+    }
 }
 
 void NewInstanceDialog::importIconNow()

--- a/launcher/ui/dialogs/NewInstanceDialog.h
+++ b/launcher/ui/dialogs/NewInstanceDialog.h
@@ -56,10 +56,13 @@ public:
 public slots:
     void accept() override;
     void reject() override;
+    void onFocusChanged(QWidget *, QWidget *newWidget);
 
 private slots:
     void on_iconButton_clicked();
+    void on_resetNameButton_clicked();
     void on_instNameTextBox_textChanged(const QString &arg1);
+    void on_instNameTextBox_textEdited(const QString &text);
 
 private:
     Ui::NewInstanceDialog *ui = nullptr;
@@ -75,4 +78,7 @@ private:
     QString importIconName;
 
     void importIconNow();
+
+    QString defaultInstName;
+    bool instNameChanged = false;
 };

--- a/launcher/ui/dialogs/NewInstanceDialog.ui
+++ b/launcher/ui/dialogs/NewInstanceDialog.ui
@@ -26,10 +26,23 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout_2">
+     <item row="0" column="2">
+      <widget class="QLineEdit" name="instNameTextBox"/>
+     </item>
      <item row="1" column="2">
       <widget class="QComboBox" name="groupBox">
        <property name="editable">
         <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="nameLabel">
+       <property name="text">
+        <string>&amp;Name:</string>
+       </property>
+       <property name="buddy">
+        <cstring>instNameTextBox</cstring>
        </property>
       </widget>
      </item>
@@ -43,19 +56,6 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="2">
-      <widget class="QLineEdit" name="instNameTextBox"/>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLabel" name="nameLabel">
-       <property name="text">
-        <string>&amp;Name:</string>
-       </property>
-       <property name="buddy">
-        <cstring>instNameTextBox</cstring>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="0" rowspan="2">
       <widget class="QToolButton" name="iconButton">
        <property name="iconSize">
@@ -63,6 +63,13 @@
          <width>80</width>
          <height>80</height>
         </size>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3">
+      <widget class="QPushButton" name="resetNameButton">
+       <property name="text">
+        <string>Reset</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Fills the instance name in instead of just setting a placeholder. This allows adjustments to be made to the suggested name without typing the whole thing out.
The text is selected by default so that typing will overwrite the text, but users who want to adjust the default name instead of typing their own can deselect the text.
The placeholder name is still set so it is still visible if the user deletes the text.
Also sets the focus to the instance name textbox by default, whereas previously it was on the group name - this is required so the text gets overwritten on typing but also makes more sense generally.
Closes issue #4812.