### PR TITLE
Sandbox MultiMC launcher

### DIFF
--- a/launcher/Launcher.in
+++ b/launcher/Launcher.in
@@ -14,7 +14,7 @@ if [[ $EUID -eq 0 ]]; then
 fi
 
 
-LAUNCHER_NAME=MultiMC
+LAUNCHER_NAME=@Launcher_Name@
 LAUNCHER_DIR="$(dirname "$(readlink -f "$0")")"
 echo "Launcher Dir: ${LAUNCHER_DIR}"
 

--- a/launcher/Launcher.in
+++ b/launcher/Launcher.in
@@ -14,7 +14,7 @@ if [[ $EUID -eq 0 ]]; then
 fi
 
 
-LAUNCHER_NAME=@Launcher_Name@
+LAUNCHER_NAME=MultiMC
 LAUNCHER_DIR="$(dirname "$(readlink -f "$0")")"
 echo "Launcher Dir: ${LAUNCHER_DIR}"
 
@@ -29,24 +29,26 @@ export QT_FONTPATH="${LAUNCHER_DIR}/fonts"
 # Detect missing dependencies...
 DEPS_LIST=`ldd "${LAUNCHER_DIR}"/plugins/*/*.so 2>/dev/null | grep "not found" | sort -u | awk -vORS=", " '{ print $1 }'`
 if [ "x$DEPS_LIST" = "x" ]; then
-    # We have all our dependencies. Run the launcher.
-    echo "No missing dependencies found."
+    if [ "$1" != "--dry-run" ]; then
+        # We have all our dependencies. Run the launcher.
+        echo "No missing dependencies found."
 
-    # Just to be sure...
-    chmod +x "${LAUNCHER_DIR}/bin/${LAUNCHER_NAME}"
+        # Just to be sure...
+        chmod +x "${LAUNCHER_DIR}/bin/${LAUNCHER_NAME}"
 
-    # Run the launcher
-    exec -a "${LAUNCHER_DIR}/${LAUNCHER_NAME}" "${LAUNCHER_DIR}/bin/${LAUNCHER_NAME}" -d "${LAUNCHER_DIR}" "$@"
+        # Run the launcher
+        exec -a "${LAUNCHER_DIR}/${LAUNCHER_NAME}" "${LAUNCHER_DIR}/bin/${LAUNCHER_NAME}" -d "${LAUNCHER_DIR}" "$@"
 
-    # Run the launcher in valgrind
-    # valgrind --log-file="valgrind.log" --leak-check=full --track-origins=yes "${LAUNCHER_DIR}/bin/${LAUNCHER_NAME}" -d "${LAUNCHER_DIR}" "$@"
+        # Run the launcher in valgrind
+        # valgrind --log-file="valgrind.log" --leak-check=full --track-origins=yes "${LAUNCHER_DIR}/bin/${LAUNCHER_NAME}" -d "${LAUNCHER_DIR}" "$@"
 
-    # Run the launcher with callgrind, delay instrumentation
-    # valgrind --log-file="valgrind.log" --tool=callgrind --instr-atstart=no "${LAUNCHER_DIR}/bin/${LAUNCHER_NAME}" -d "${LAUNCHER_DIR}" "$@"
-    # use callgrind_control -i on/off to profile actions
+        # Run the launcher with callgrind, delay instrumentation
+        # valgrind --log-file="valgrind.log" --tool=callgrind --instr-atstart=no "${LAUNCHER_DIR}/bin/${LAUNCHER_NAME}" -d "${LAUNCHER_DIR}" "$@"
+        # use callgrind_control -i on/off to profile actions
 
-    # Exit with launcher's exit code.
-    # exit $?
+        # Exit with launcher's exit code.
+        # exit $?
+    fi
 else
     # apt
     if which apt-file &>/dev/null; then

--- a/launcher/package/rpm/MultiMC5.spec
+++ b/launcher/package/rpm/MultiMC5.spec
@@ -9,7 +9,7 @@ ExclusiveArch:  %{ix86} x86_64
 
 BuildRequires:  desktop-file-utils
 BuildRequires:  libappstream-glib
-Requires:       zenity %{?suse_version:lib}qt5-qtbase wget xrandr
+Requires:       zenity %{?suse_version:lib}qt5-qtbase wget xrandr bubblewrap
 Provides:       multimc = %{version}
 Provides:       MultiMC = %{version}
 Provides:       multimc5 = %{version}

--- a/launcher/package/ubuntu/multimc/DEBIAN/control
+++ b/launcher/package/ubuntu/multimc/DEBIAN/control
@@ -5,7 +5,7 @@ Maintainer: Petr Mrázek <peterix@gmail.com>
 Section: games
 Priority: optional
 Installed-Size: 75
-Depends: zenity, desktop-file-utils, libqt5widgets5, libqt5gui5, libqt5network5, libqt5core5a, libqt5xml5, libqt5concurrent5, wget
+Depends: zenity, desktop-file-utils, libqt5widgets5, libqt5gui5, libqt5network5, libqt5core5a, libqt5xml5, libqt5concurrent5, wget, bubblewrap
 Recommends: openjdk-8-jre
 Homepage: http://multimc.org
 Description: A local install wrapper for MultiMC

--- a/launcher/package/ubuntu/multimc/opt/multimc/run.sh
+++ b/launcher/package/ubuntu/multimc/opt/multimc/run.sh
@@ -23,61 +23,54 @@ deploy() {
 runmmc() {
     cd ${INSTDIR}
     source ./MultiMC --dry-run
+    bash
+exit
     path_fwd=""
     # Now to setup binds for the execution environment
-    # This allows the sandbox to dynamically grant permission to PATH entries and preloaded libraries
-    # This would be more useful if we weren't already `ro-bind`ing the entire filesystem root, but
-    # at least the boilerplate is completed for when someone eventually restricts permissions
-    # more granularly
+    echo "$GAME_LIBRARY_PATH"
     while read line; do
         [ "$line" == "" ] && continue
-        path_fwd="$path_fwd --ro-bind-try '$line' '$line'"
+	path_fwd="$path_fwd --ro-bind-try '$line' '$line'"
     done <<< "$(echo "$GAME_LIBRARY_PATH" | tr ':' '\n')"
+    echo "$GAME_PRELOAD"
     while read line; do
         [ "$line" == "" ] && continue
         line="$(dirname "$line")" # Binding the parent directory is easier than messing around with an unknown number of file descriptors
         path_fwd="$path_fwd --ro-bind-try '$line' '$line'" # even if it *is* somewhat lazy
     done <<< "$(echo "$GAME_PRELOAD" | tr ':' '\n')"
+    echo "$LD_LIBRARY_PATH"
     while read line; do
         [ "$line" == "" ] && continue
         path_fwd="$path_fwd --ro-bind-try '$line' '$line'"
     done <<< "$(echo "$LD_LIBRARY_PATH" | tr ':' '\n')"
+    echo "$LD_PRELOAD"
     while read line; do
         [ "$line" == "" ] && continue
-        line="$(dirname "$line")"
+	line="$(dirname "$line")"
         path_fwd="$path_fwd --ro-bind-try '$line' '$line'"
     done <<< "$(echo "$LD_PRELOAD" | tr ':' '\n')"
+    echo "$QT_PLUGIN_PATH"
     while read line; do
         [ "$line" == "" ] && continue
         path_fwd="$path_fwd --ro-bind-try '$line' '$line'"
-    done <<< "$(echo "$QT_PLUGIN__PATH" | tr ':' '\n')"
+    done <<< "$(echo "$QT_PLUGIN_PATH" | tr ':' '\n')"
+    echo "$QT_FONTPATH"
     while read line; do
         [ "$line" == "" ] && continue
         path_fwd="$path_fwd --ro-bind-try '$line' '$line'"
     done <<< "$(echo "$QT_FONTPATH" | tr ':' '\n')"
-        # This sandbox script was written to provide as much isolation as reasonably possible for a MultiMC instance
-        # However, it's not as well-restricted as I'd like. I'd prefer to replace `--ro-bind / /` with more specific binds
-        # to limit MultiMC's read access to the host filesystem as much as possible.
-        # Filesystem permissions should be sufficient in most cases, but I prefer not to even give that much access
-        # since this could still allow an attacker to see system configuration information or read system files that the user
-        # has read access to, such as potentially-sensitive configuration files
-        #
-        # Security considerations include:
-        # - This script doesn't restrict access to the host's root as much as I'd like
-        # - This script doesn't perform any X11 sandboxing at all
-        #   - This means attacks like X11 keylogging are still a risk, even from within the sandbox. So don't type your root password while MultiMC is open
-        #   - Systems running Wayland are implicitly immune to X11 keylogging, except for Sway, which is actually still vulnerable to X11 keylogging
-        # - This script doesn't implement seccomp, so the kernel attack surface isn't restricted at all
-        #   - This shouldn't be too big of a deal if you trust your kernel to be secure enough. The threat model is mostly skiddies and low-effort attacks so I think it's fine-ish
-        #
-        # The main motivation for this was the (not-so-)recent log4j vulnerability. I'd like a way to restrict what someone
-        # can do if they manage to successfully infect my system through a Minecraft/Java vulnerability, especially if I
-        # intend to play online on older Minecraft versions that will likely never see a log4j fix
-        # While I'm aware that MultiMC already has a patched version of log4j, I think it makes sense to additionally
-        # sandbox the entire launcher
-        #
-        # This has the additional benefit of mitigating potential future exploits that we don't know about yet
-        # Note that this adds an additional dependency to the launcher: Bubblewrap. This is unavoidable if we want to use Bubblewrap to sandbox the game
+	# This sandbox script was written to provide as much isolation as reasonably possible for a MultiMC instance
+	# However, it's not as well-restricted as I'd like. I'd prefer to replace `--ro-bind / /` with more specific binds
+	# to limit MultiMC's read access to the host filesystem as much as possible.
+	# Filesystem permissions should be sufficient in most cases, but I prefer not to even give that much access
+	#
+	# Security considerations include:
+	# - This script doesn't restrict access to the host's root as much as I'd like
+	# - This script doesn't perform any X11 sandboxing at all
+	# - This script doesn't implement seccomp, so the kernel attack surface isn't restricted at all
+	# The main motivation for this was the (not-so-)recent log4j vulnerability. I'd like a way to restrict what someone
+	# can do if they manage to successfully infect my system through a Minecraft/Java vulnerability, especially if I
+	# intend to play online on older Minecraft versions that will likely never see a log4j fix
     bwrap --die-with-parent --cap-drop all --new-session --unshare-all --share-net \
         --ro-bind / / --tmpfs /tmp --tmpfs /home --tmpfs /root --dev-bind-try /dev /dev --proc /proc \
         $path_fwd --bind "$INSTDIR" "$INSTDIR" \

--- a/launcher/package/ubuntu/multimc/opt/multimc/run.sh
+++ b/launcher/package/ubuntu/multimc/opt/multimc/run.sh
@@ -31,7 +31,7 @@ runmmc() {
     # more granularly
     while read line; do
         [ "$line" == "" ] && continue
-	path_fwd="$path_fwd --ro-bind-try '$line' '$line'"
+        path_fwd="$path_fwd --ro-bind-try '$line' '$line'"
     done <<< "$(echo "$GAME_LIBRARY_PATH" | tr ':' '\n')"
     while read line; do
         [ "$line" == "" ] && continue
@@ -44,7 +44,7 @@ runmmc() {
     done <<< "$(echo "$LD_LIBRARY_PATH" | tr ':' '\n')"
     while read line; do
         [ "$line" == "" ] && continue
-	line="$(dirname "$line")"
+        line="$(dirname "$line")"
         path_fwd="$path_fwd --ro-bind-try '$line' '$line'"
     done <<< "$(echo "$LD_PRELOAD" | tr ':' '\n')"
     while read line; do

--- a/launcher/package/ubuntu/multimc/opt/multimc/run.sh
+++ b/launcher/package/ubuntu/multimc/opt/multimc/run.sh
@@ -55,29 +55,29 @@ runmmc() {
         [ "$line" == "" ] && continue
         path_fwd="$path_fwd --ro-bind-try '$line' '$line'"
     done <<< "$(echo "$QT_FONTPATH" | tr ':' '\n')"
-	# This sandbox script was written to provide as much isolation as reasonably possible for a MultiMC instance
-	# However, it's not as well-restricted as I'd like. I'd prefer to replace `--ro-bind / /` with more specific binds
-	# to limit MultiMC's read access to the host filesystem as much as possible.
-	# Filesystem permissions should be sufficient in most cases, but I prefer not to even give that much access
-	# since this could still allow an attacker to see system configuration information or read system files that the user
-	# has read access to, such as potentially-sensitive configuration files
-	#
-	# Security considerations include:
-	# - This script doesn't restrict access to the host's root as much as I'd like
-	# - This script doesn't perform any X11 sandboxing at all
-	#   - This means attacks like X11 keylogging are still a risk, even from within the sandbox. So don't type your root password while MultiMC is open
-	#   - Systems running Wayland are implicitly immune to X11 keylogging, except for Sway, which is actually still vulnerable to X11 keylogging
-	# - This script doesn't implement seccomp, so the kernel attack surface isn't restricted at all
-	#   - This shouldn't be too big of a deal if you trust your kernel to be secure enough. The threat model is mostly skiddies and low-effort attacks so I think it's fine-ish
-	#
-	# The main motivation for this was the (not-so-)recent log4j vulnerability. I'd like a way to restrict what someone
-	# can do if they manage to successfully infect my system through a Minecraft/Java vulnerability, especially if I
-	# intend to play online on older Minecraft versions that will likely never see a log4j fix
-	# While I'm aware that MultiMC already has a patched version of log4j, I think it makes sense to additionally
-	# sandbox the entire launcher
-	#
-	# This has the additional benefit of mitigating potential future exploits that we don't know about yet
-	# Note that this adds an additional dependency to the launcher: Bubblewrap. This is unavoidable if we want to use Bubblewrap to sandbox the game
+        # This sandbox script was written to provide as much isolation as reasonably possible for a MultiMC instance
+        # However, it's not as well-restricted as I'd like. I'd prefer to replace `--ro-bind / /` with more specific binds
+        # to limit MultiMC's read access to the host filesystem as much as possible.
+        # Filesystem permissions should be sufficient in most cases, but I prefer not to even give that much access
+        # since this could still allow an attacker to see system configuration information or read system files that the user
+        # has read access to, such as potentially-sensitive configuration files
+        #
+        # Security considerations include:
+        # - This script doesn't restrict access to the host's root as much as I'd like
+        # - This script doesn't perform any X11 sandboxing at all
+        #   - This means attacks like X11 keylogging are still a risk, even from within the sandbox. So don't type your root password while MultiMC is open
+        #   - Systems running Wayland are implicitly immune to X11 keylogging, except for Sway, which is actually still vulnerable to X11 keylogging
+        # - This script doesn't implement seccomp, so the kernel attack surface isn't restricted at all
+        #   - This shouldn't be too big of a deal if you trust your kernel to be secure enough. The threat model is mostly skiddies and low-effort attacks so I think it's fine-ish
+        #
+        # The main motivation for this was the (not-so-)recent log4j vulnerability. I'd like a way to restrict what someone
+        # can do if they manage to successfully infect my system through a Minecraft/Java vulnerability, especially if I
+        # intend to play online on older Minecraft versions that will likely never see a log4j fix
+        # While I'm aware that MultiMC already has a patched version of log4j, I think it makes sense to additionally
+        # sandbox the entire launcher
+        #
+        # This has the additional benefit of mitigating potential future exploits that we don't know about yet
+        # Note that this adds an additional dependency to the launcher: Bubblewrap. This is unavoidable if we want to use Bubblewrap to sandbox the game
     bwrap --die-with-parent --cap-drop all --new-session --unshare-all --share-net \
         --ro-bind / / --tmpfs /tmp --tmpfs /home --tmpfs /root --dev-bind-try /dev /dev --proc /proc \
         $path_fwd --bind "$INSTDIR" "$INSTDIR" \

--- a/launcher/package/ubuntu/multimc/opt/multimc/run.sh
+++ b/launcher/package/ubuntu/multimc/opt/multimc/run.sh
@@ -23,8 +23,6 @@ deploy() {
 runmmc() {
     cd ${INSTDIR}
     source ./MultiMC --dry-run
-    bash
-exit
     path_fwd=""
     # Now to setup binds for the execution environment
     echo "$GAME_LIBRARY_PATH"

--- a/launcher/package/ubuntu/multimc/opt/multimc/run.sh
+++ b/launcher/package/ubuntu/multimc/opt/multimc/run.sh
@@ -25,34 +25,32 @@ runmmc() {
     source ./MultiMC --dry-run
     path_fwd=""
     # Now to setup binds for the execution environment
-    echo "$GAME_LIBRARY_PATH"
+    # This allows the sandbox to dynamically grant permission to PATH entries and preloaded libraries
+    # This would be more useful if we weren't already `ro-bind`ing the entire filesystem root, but
+    # at least the boilerplate is completed for when someone eventually restricts permissions
+    # more granularly
     while read line; do
         [ "$line" == "" ] && continue
 	path_fwd="$path_fwd --ro-bind-try '$line' '$line'"
     done <<< "$(echo "$GAME_LIBRARY_PATH" | tr ':' '\n')"
-    echo "$GAME_PRELOAD"
     while read line; do
         [ "$line" == "" ] && continue
         line="$(dirname "$line")" # Binding the parent directory is easier than messing around with an unknown number of file descriptors
         path_fwd="$path_fwd --ro-bind-try '$line' '$line'" # even if it *is* somewhat lazy
     done <<< "$(echo "$GAME_PRELOAD" | tr ':' '\n')"
-    echo "$LD_LIBRARY_PATH"
     while read line; do
         [ "$line" == "" ] && continue
         path_fwd="$path_fwd --ro-bind-try '$line' '$line'"
     done <<< "$(echo "$LD_LIBRARY_PATH" | tr ':' '\n')"
-    echo "$LD_PRELOAD"
     while read line; do
         [ "$line" == "" ] && continue
 	line="$(dirname "$line")"
         path_fwd="$path_fwd --ro-bind-try '$line' '$line'"
     done <<< "$(echo "$LD_PRELOAD" | tr ':' '\n')"
-    echo "$QT_PLUGIN_PATH"
     while read line; do
         [ "$line" == "" ] && continue
         path_fwd="$path_fwd --ro-bind-try '$line' '$line'"
     done <<< "$(echo "$QT_PLUGIN__PATH" | tr ':' '\n')"
-    echo "$QT_FONTPATH"
     while read line; do
         [ "$line" == "" ] && continue
         path_fwd="$path_fwd --ro-bind-try '$line' '$line'"
@@ -61,14 +59,25 @@ runmmc() {
 	# However, it's not as well-restricted as I'd like. I'd prefer to replace `--ro-bind / /` with more specific binds
 	# to limit MultiMC's read access to the host filesystem as much as possible.
 	# Filesystem permissions should be sufficient in most cases, but I prefer not to even give that much access
+	# since this could still allow an attacker to see system configuration information or read system files that the user
+	# has read access to, such as potentially-sensitive configuration files
 	#
 	# Security considerations include:
 	# - This script doesn't restrict access to the host's root as much as I'd like
 	# - This script doesn't perform any X11 sandboxing at all
+	#   - This means attacks like X11 keylogging are still a risk, even from within the sandbox. So don't type your root password while MultiMC is open
+	#   - Systems running Wayland are implicitly immune to X11 keylogging, except for Sway, which is actually still vulnerable to X11 keylogging
 	# - This script doesn't implement seccomp, so the kernel attack surface isn't restricted at all
+	#   - This shouldn't be too big of a deal if you trust your kernel to be secure enough. The threat model is mostly skiddies and low-effort attacks so I think it's fine-ish
+	#
 	# The main motivation for this was the (not-so-)recent log4j vulnerability. I'd like a way to restrict what someone
 	# can do if they manage to successfully infect my system through a Minecraft/Java vulnerability, especially if I
 	# intend to play online on older Minecraft versions that will likely never see a log4j fix
+	# While I'm aware that MultiMC already has a patched version of log4j, I think it makes sense to additionally
+	# sandbox the entire launcher
+	#
+	# This has the additional benefit of mitigating potential future exploits that we don't know about yet
+	# Note that this adds an additional dependency to the launcher: Bubblewrap. This is unavoidable if we want to use Bubblewrap to sandbox the game
     bwrap --die-with-parent --cap-drop all --new-session --unshare-all --share-net \
         --ro-bind / / --tmpfs /tmp --tmpfs /home --tmpfs /root --dev-bind-try /dev /dev --proc /proc \
         $path_fwd --bind "$INSTDIR" "$INSTDIR" \

--- a/launcher/package/ubuntu/multimc/opt/multimc/run.sh
+++ b/launcher/package/ubuntu/multimc/opt/multimc/run.sh
@@ -80,14 +80,10 @@ runmmc() {
         --ro-bind /lib /lib --ro-bind-try /lib64 /lib64 --ro-bind-try /lib32 /lib32 \
         --ro-bind /usr/lib /usr/lib \
         $path_fwd --bind "$INSTDIR" "$INSTDIR" \
-        --setenv PATH /usr/bin:/bin \
-        --dir /run/user/"$UID" \
         --ro-bind-try /run/user/"$UID"/pulse /run/user/"$UID"/pulse \
         --ro-bind-try /run/user/"$UID"/pipewire-0 /run/user/"$UID"/pipewire-0 \
         --ro-bind-try /tmp/.X11-unix/X0 /tmp/.X11-unix/X0 \
         --ro-bind-try /run/user/"$UID"/wayland-1 /run/user/"$UID"/wayland-1 \
-        --setenv XDG_RUNTIME_DIR /run/user/"$UID" \
-        --setenv DISPLAY "$DISPLAY" \
         --ro-bind /etc/fonts /etc/fonts \
         --ro-bind /usr/share/icons /usr/share/icons \
         --ro-bind /usr/share/mime /usr/share/mime \

--- a/launcher/package/ubuntu/multimc/opt/multimc/run.sh
+++ b/launcher/package/ubuntu/multimc/opt/multimc/run.sh
@@ -22,7 +22,57 @@ deploy() {
 
 runmmc() {
     cd ${INSTDIR}
-    exec ./MultiMC "$@"
+    source ./MultiMC --dry-run
+    path_fwd=""
+    # Now to setup binds for the execution environment
+    echo "$GAME_LIBRARY_PATH"
+    while read line; do
+        [ "$line" == "" ] && continue
+	path_fwd="$path_fwd --ro-bind-try '$line' '$line'"
+    done <<< "$(echo "$GAME_LIBRARY_PATH" | tr ':' '\n')"
+    echo "$GAME_PRELOAD"
+    while read line; do
+        [ "$line" == "" ] && continue
+        line="$(dirname "$line")" # Binding the parent directory is easier than messing around with an unknown number of file descriptors
+        path_fwd="$path_fwd --ro-bind-try '$line' '$line'" # even if it *is* somewhat lazy
+    done <<< "$(echo "$GAME_PRELOAD" | tr ':' '\n')"
+    echo "$LD_LIBRARY_PATH"
+    while read line; do
+        [ "$line" == "" ] && continue
+        path_fwd="$path_fwd --ro-bind-try '$line' '$line'"
+    done <<< "$(echo "$LD_LIBRARY_PATH" | tr ':' '\n')"
+    echo "$LD_PRELOAD"
+    while read line; do
+        [ "$line" == "" ] && continue
+	line="$(dirname "$line")"
+        path_fwd="$path_fwd --ro-bind-try '$line' '$line'"
+    done <<< "$(echo "$LD_PRELOAD" | tr ':' '\n')"
+    echo "$QT_PLUGIN_PATH"
+    while read line; do
+        [ "$line" == "" ] && continue
+        path_fwd="$path_fwd --ro-bind-try '$line' '$line'"
+    done <<< "$(echo "$QT_PLUGIN__PATH" | tr ':' '\n')"
+    echo "$QT_FONTPATH"
+    while read line; do
+        [ "$line" == "" ] && continue
+        path_fwd="$path_fwd --ro-bind-try '$line' '$line'"
+    done <<< "$(echo "$QT_FONTPATH" | tr ':' '\n')"
+	# This sandbox script was written to provide as much isolation as reasonably possible for a MultiMC instance
+	# However, it's not as well-restricted as I'd like. I'd prefer to replace `--ro-bind / /` with more specific binds
+	# to limit MultiMC's read access to the host filesystem as much as possible.
+	# Filesystem permissions should be sufficient in most cases, but I prefer not to even give that much access
+	#
+	# Security considerations include:
+	# - This script doesn't restrict access to the host's root as much as I'd like
+	# - This script doesn't perform any X11 sandboxing at all
+	# - This script doesn't implement seccomp, so the kernel attack surface isn't restricted at all
+	# The main motivation for this was the (not-so-)recent log4j vulnerability. I'd like a way to restrict what someone
+	# can do if they manage to successfully infect my system through a Minecraft/Java vulnerability, especially if I
+	# intend to play online on older Minecraft versions that will likely never see a log4j fix
+    bwrap --die-with-parent --cap-drop all --new-session --unshare-all --share-net \
+        --ro-bind / / --tmpfs /tmp --tmpfs /home --tmpfs /root --dev-bind-try /dev /dev --proc /proc \
+        $path_fwd --bind "$INSTDIR" "$INSTDIR" \
+    ./MultiMC "$@"
 }
 
 if [[ ! -f ${INSTDIR}/MultiMC ]]; then

--- a/launcher/package/ubuntu/multimc/opt/multimc/run.sh
+++ b/launcher/package/ubuntu/multimc/opt/multimc/run.sh
@@ -57,6 +57,11 @@ runmmc() {
         [ "$line" == "" ] && continue
         path_fwd="$path_fwd --ro-bind-try '$line' '$line'"
     done <<< "$(echo "$QT_FONTPATH" | tr ':' '\n')"
+
+    for f in /etc/java*/; do
+        path_fwd="$path_fwd --ro-bind $f $f"
+    done
+
 	# This sandbox script was written to provide as much isolation as reasonably possible for a MultiMC instance
 	# However, it's not as well-restricted as I'd like. I'd prefer to replace `--ro-bind / /` with more specific binds
 	# to limit MultiMC's read access to the host filesystem as much as possible.
@@ -70,8 +75,28 @@ runmmc() {
 	# can do if they manage to successfully infect my system through a Minecraft/Java vulnerability, especially if I
 	# intend to play online on older Minecraft versions that will likely never see a log4j fix
     bwrap --die-with-parent --cap-drop all --new-session --unshare-all --share-net \
-        --ro-bind / / --tmpfs /tmp --tmpfs /home --tmpfs /root --dev-bind-try /dev /dev --proc /proc \
+        --tmpfs / --tmpfs /tmp --tmpfs /home --tmpfs /root --dev-bind /dev /dev --proc /proc \
+        --ro-bind /usr/bin /usr/bin --bind /bin /bin --ro-bind-try /etc/alternatives /etc/alternatives \
+        --ro-bind /lib /lib --ro-bind-try /lib64 /lib64 --ro-bind-try /lib32 /lib32 \
+        --ro-bind /usr/lib /usr/lib \
         $path_fwd --bind "$INSTDIR" "$INSTDIR" \
+        --setenv PATH /usr/bin:/bin \
+        --dir /run/user/"$UID" \
+        --ro-bind-try /run/user/"$UID"/pulse /run/user/"$UID"/pulse \
+        --ro-bind-try /run/user/"$UID"/pipewire-0 /run/user/"$UID"/pipewire-0 \
+        --ro-bind-try /tmp/.X11-unix/X0 /tmp/.X11-unix/X0 \
+        --ro-bind-try /run/user/"$UID"/wayland-1 /run/user/"$UID"/wayland-1 \
+        --setenv XDG_RUNTIME_DIR "/run/user/$UID" \
+        --setenv DISPLAY "$DISPLAY" \
+        --ro-bind /etc/fonts /etc/fonts \
+        --ro-bind /usr/share/icons /usr/share/icons \
+        --ro-bind /usr/share/mime /usr/share/mime \
+        --ro-bind /usr/share/fontconfig /usr/share/fontconfig \
+        --ro-bind /usr/share/fonts /usr/share/fonts \
+        --ro-bind /etc/resolv.conf /etc/resolv.conf \
+        --ro-bind /etc/ssl /etc/ssl \
+        --ro-bind /etc/ca-certificates /etc/ca-certificates \
+        --ro-bind /usr/share /usr/share \
     ./MultiMC "$@"
 }
 

--- a/launcher/package/ubuntu/multimc/opt/multimc/run.sh
+++ b/launcher/package/ubuntu/multimc/opt/multimc/run.sh
@@ -86,7 +86,7 @@ runmmc() {
         --ro-bind-try /run/user/"$UID"/pipewire-0 /run/user/"$UID"/pipewire-0 \
         --ro-bind-try /tmp/.X11-unix/X0 /tmp/.X11-unix/X0 \
         --ro-bind-try /run/user/"$UID"/wayland-1 /run/user/"$UID"/wayland-1 \
-        --setenv XDG_RUNTIME_DIR "/run/user/$UID" \
+        --setenv XDG_RUNTIME_DIR /run/user/"$UID" \
         --setenv DISPLAY "$DISPLAY" \
         --ro-bind /etc/fonts /etc/fonts \
         --ro-bind /usr/share/icons /usr/share/icons \


### PR DESCRIPTION
The main motivation for this was the (not-so-)recent log4j vulnerability. I'd like a way to restrict what someone can do if they manage to successfully infect my system through a Minecraft/Java vulnerability, especially if I intend to play online on older Minecraft versions that will likely never see a log4j fix. While I'm aware that MultiMC already has a patched version of log4j, I think it makes sense to additionally sandbox the entire launcher. This has the additional benefit of mitigating potential future exploits that we don't know about yet

Note that this adds an additional dependency to the launcher: Bubblewrap. This is unavoidable if we want to use Bubblewrap to sandbox the game