### PR TITLE
NOISSUE Quote Instance ID when creating a shortcut

### DIFF
--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -113,7 +113,7 @@ QString CreateShortcutDialog::getLaunchCommand()
 QString CreateShortcutDialog::getLaunchArgs()
 {
     return " -d \"" + QDir::toNativeSeparators(QDir::currentPath()) + "\""
-           + " -l " + m_instance->id()
+           + " -l \"" + m_instance->id() + "\""
            + (ui->joinServerCheckBox->isChecked() ? " -s " + ui->joinServer->text() : "")
            + (ui->useProfileCheckBox->isChecked() ? " -a " + ui->profileComboBox->currentText() : "")
            + (ui->launchOfflineCheckBox->isChecked() ? " -o" : "")


### PR DESCRIPTION
When a shortcut is created if the instance folder contains spaces, the instance will fail to launch from the shortcut as it does not correctly handle the spaces in the `-l` argument.

To fix this issue we should correctly quote the Instance ID value.