### PR TITLE
Record where packs come from

### DIFF
--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -1,4 +1,5 @@
 /* Copyright 2013-2021 MultiMC Contributors
+ * Copyright 2022 Jamie Mansfield <jmansfield@cadixdev.org>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +56,14 @@ BaseInstance::BaseInstance(SettingsObjectPtr globalSettings, SettingsObjectPtr s
 
     m_settings->registerPassthrough(globalSettings->getSetting("ConsoleMaxLines"), nullptr);
     m_settings->registerPassthrough(globalSettings->getSetting("ConsoleOverflowStop"), nullptr);
+
+    // Managed Packs
+    m_settings->registerSetting("ManagedPack", false);
+    m_settings->registerSetting("ManagedPackType", "");
+    m_settings->registerSetting("ManagedPackID", "");
+    m_settings->registerSetting("ManagedPackName", "");
+    m_settings->registerSetting("ManagedPackVersionID", "");
+    m_settings->registerSetting("ManagedPackVersionName", "");
 }
 
 QString BaseInstance::getPreLaunchCommand()
@@ -70,6 +79,46 @@ QString BaseInstance::getWrapperCommand()
 QString BaseInstance::getPostExitCommand()
 {
     return settings()->get("PostExitCommand").toString();
+}
+
+bool BaseInstance::isManagedPack()
+{
+    return settings()->get("ManagedPack").toBool();
+}
+
+QString BaseInstance::getManagedPackType()
+{
+    return settings()->get("ManagedPackType").toString();
+}
+
+QString BaseInstance::getManagedPackID()
+{
+    return settings()->get("ManagedPackID").toString();
+}
+
+QString BaseInstance::getManagedPackName()
+{
+    return settings()->get("ManagedPackName").toString();
+}
+
+QString BaseInstance::getManagedPackVersionID()
+{
+    return settings()->get("ManagedPackVersionID").toString();
+}
+
+QString BaseInstance::getManagedPackVersionName()
+{
+    return settings()->get("ManagedPackVersionName").toString();
+}
+
+void BaseInstance::setManagedPack(const QString& type, const QString& id, const QString& name, const QString& versionId, const QString& version)
+{
+    settings()->set("ManagedPack", true);
+    settings()->set("ManagedPackType", type);
+    settings()->set("ManagedPackID", id);
+    settings()->set("ManagedPackName", name);
+    settings()->set("ManagedPackVersionID", versionId);
+    settings()->set("ManagedPackVersionName", version);
 }
 
 int BaseInstance::getConsoleMaxLines() const

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -1,4 +1,5 @@
 /* Copyright 2013-2021 MultiMC Contributors
+ * Copyright 2022 Jamie Mansfield <jmansfield@cadixdev.org>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,6 +119,14 @@ public:
     QString getPreLaunchCommand();
     QString getPostExitCommand();
     QString getWrapperCommand();
+
+    bool isManagedPack();
+    QString getManagedPackType();
+    QString getManagedPackID();
+    QString getManagedPackName();
+    QString getManagedPackVersionID();
+    QString getManagedPackVersionName();
+    void setManagedPack(const QString& type, const QString& id, const QString& name, const QString& versionId, const QString& version);
 
     /// guess log level from a line of game log
     virtual MessageLevel::Enum guessLevel(const QString &line, MessageLevel::Enum level)

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
@@ -815,6 +815,7 @@ void PackInstallTask::install()
 
     instance.setName(m_instName);
     instance.setIconKey(m_instIcon);
+    instance.setManagedPack("atlauncher", m_pack_safe_name, m_pack_name, m_version_name, m_version_name);
     instanceSettings->resumeSave();
 
     jarmods.clear();

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
@@ -39,10 +39,11 @@
 
 namespace ATLauncher {
 
-PackInstallTask::PackInstallTask(UserInteractionSupport *support, QString pack, QString version)
+PackInstallTask::PackInstallTask(UserInteractionSupport *support, QString packName, QString version)
 {
     m_support = support;
-    m_pack = pack;
+    m_pack_name = packName;
+    m_pack_safe_name = packName.replace(QRegularExpression("[^A-Za-z0-9]"), "");
     m_version_name = version;
 }
 
@@ -60,7 +61,7 @@ void PackInstallTask::executeTask()
     qDebug() << "PackInstallTask::executeTask: " << QThread::currentThreadId();
     auto *netJob = new NetJob("ATLauncher::VersionFetch", APPLICATION->network());
     auto searchUrl = QString(BuildConfig.ATL_DOWNLOAD_SERVER_URL + "packs/%1/versions/%2/Configs.json")
-            .arg(m_pack).arg(m_version_name);
+            .arg(m_pack_safe_name).arg(m_version_name);
     netJob->addNetAction(Net::Download::makeByteArray(QUrl(searchUrl), &response));
     jobPtr = netJob;
     jobPtr->start();
@@ -307,7 +308,7 @@ bool PackInstallTask::createLibrariesComponent(QString instanceRoot, std::shared
     auto patchFileName = FS::PathCombine(patchDir, target_id + ".json");
 
     auto f = std::make_shared<VersionFile>();
-    f->name = m_pack + " " + m_version_name + " (libraries)";
+    f->name = m_pack_name + " " + m_version_name + " (libraries)";
 
     for(const auto & lib : m_version.libraries) {
         auto libName = detectLibrary(lib);
@@ -412,7 +413,7 @@ bool PackInstallTask::createPackComponent(QString instanceRoot, std::shared_ptr<
     }
 
     auto f = std::make_shared<VersionFile>();
-    f->name = m_pack + " " + m_version_name;
+    f->name = m_pack_name + " " + m_version_name;
     if(!mainClass.isEmpty() && !mainClasses.contains(mainClass)) {
         f->mainClass = mainClass;
     }
@@ -454,9 +455,9 @@ void PackInstallTask::installConfigs()
     setStatus(tr("Downloading configs..."));
     jobPtr = new NetJob(tr("Config download"), APPLICATION->network());
 
-    auto path = QString("Configs/%1/%2.zip").arg(m_pack).arg(m_version_name);
+    auto path = QString("Configs/%1/%2.zip").arg(m_pack_safe_name).arg(m_version_name);
     auto url = QString(BuildConfig.ATL_DOWNLOAD_SERVER_URL + "packs/%1/versions/%2/Configs.zip")
-            .arg(m_pack).arg(m_version_name);
+            .arg(m_pack_safe_name).arg(m_version_name);
     auto entry = APPLICATION->metacache()->resolveEntry("ATLauncherPacks", path);
     entry->setStale(true);
 

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.h
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.h
@@ -57,7 +57,7 @@ class PackInstallTask : public InstanceTask
 Q_OBJECT
 
 public:
-    explicit PackInstallTask(UserInteractionSupport *support, QString pack, QString version);
+    explicit PackInstallTask(UserInteractionSupport *support, QString packName, QString version);
     virtual ~PackInstallTask(){}
 
     bool canAbort() const override { return true; }
@@ -99,7 +99,8 @@ private:
     NetJob::Ptr jobPtr;
     QByteArray response;
 
-    QString m_pack;
+    QString m_pack_name;
+    QString m_pack_safe_name;
     QString m_version_name;
     PackVersion m_version;
 

--- a/launcher/ui/pages/modplatform/atlauncher/AtlPage.cpp
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlPage.cpp
@@ -91,7 +91,7 @@ void AtlPage::suggestCurrent()
         return;
     }
 
-    dialog->setSuggestedPack(selected.name + " " + selectedVersion, new ATLauncher::PackInstallTask(this, selected.safeName, selectedVersion));
+    dialog->setSuggestedPack(selected.name + " " + selectedVersion, new ATLauncher::PackInstallTask(this, selected.name, selectedVersion));
     auto editedLogoName = selected.safeName;
     auto url = QString(BuildConfig.ATL_DOWNLOAD_SERVER_URL + "launcher/images/%1.png").arg(selected.safeName.toLower());
     listModel->getLogo(selected.safeName, url, [this, editedLogoName](QString logo)


### PR DESCRIPTION
Here lies some basic changes to support storing pack metadata (for managed packs). This lays the groundwork for supporting updating/reinstalling packs in future, using platform-specific logic.

Currently metadata is stored for packs installed through ATLauncher. I have yet to look into the other platforms supported now.

---

An example of the metadata stored (DNS Techpack / ATLauncher):

```
InstanceType=OneSix
ManagedPack=true
ManagedPackID=DNSTechpack
ManagedPackName=DNS Techpack
ManagedPackType=atlauncher
ManagedPackVersionID=14.1.8
ManagedPackVersionName=14.1.8
iconKey=DNSTechpack
name=DNS Techpack 14.1.8
```

---

<img width="901" alt="image" src="https://user-images.githubusercontent.com/5103549/196745121-6174823b-4272-4900-bd04-69fa20dc1e8a.png">

This is the sort of platform-specific UI / logic that I envision this going towards - and have implemented for my personal fork. Though I appreciate that this will likely need to adapted to MultiMC's views.
