### PR TITLE
Technic: Display available versions for Solder packs

### DIFF
--- a/buildconfig/BuildConfig.h
+++ b/buildconfig/BuildConfig.h
@@ -100,6 +100,12 @@ public:
 
     QString ATL_DOWNLOAD_SERVER_URL = "https://download.nodecdn.net/containers/atl/";
 
+    QString TECHNIC_API_BASE_URL = "https://api.technicpack.net/";
+    /**
+     * The build that is reported to the Technic API.
+     */
+    QString TECHNIC_API_BUILD = "multimc";
+
     /**
      * \brief Converts the Version to a string.
      * \return The version number in string format (major.minor.revision.build).

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -509,6 +509,8 @@ set(TECHNIC_SOURCES
     modplatform/technic/SingleZipPackInstallTask.cpp
     modplatform/technic/SolderPackInstallTask.h
     modplatform/technic/SolderPackInstallTask.cpp
+    modplatform/technic/SolderPackManifest.h
+    modplatform/technic/SolderPackManifest.cpp
     modplatform/technic/TechnicPackProcessor.h
     modplatform/technic/TechnicPackProcessor.cpp
 )

--- a/launcher/modplatform/technic/SolderPackInstallTask.h
+++ b/launcher/modplatform/technic/SolderPackInstallTask.h
@@ -1,4 +1,5 @@
 /* Copyright 2013-2021 MultiMC Contributors
+ * Copyright 2021 Jamie Mansfield <jmansfield@cadixdev.org>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +28,7 @@ namespace Technic
     {
         Q_OBJECT
     public:
-        explicit SolderPackInstallTask(shared_qobject_ptr<QNetworkAccessManager> network, const QUrl &sourceUrl, const QString &minecraftVersion);
+        explicit SolderPackInstallTask(shared_qobject_ptr<QNetworkAccessManager> network, const QUrl &sourceUrl, const QString& version, const QString &minecraftVersion);
 
         bool canAbort() const override { return true; }
         bool abort() override;
@@ -37,7 +38,6 @@ namespace Technic
         virtual void executeTask() override;
 
     private slots:
-        void versionSucceeded();
         void fileListSucceeded();
         void downloadSucceeded();
         void downloadFailed(QString reason);
@@ -52,6 +52,7 @@ namespace Technic
 
         NetJob::Ptr m_filesNetJob;
         QUrl m_sourceUrl;
+        QString m_version;
         QString m_minecraftVersion;
         QByteArray m_response;
         QTemporaryDir m_outputDir;

--- a/launcher/modplatform/technic/SolderPackManifest.cpp
+++ b/launcher/modplatform/technic/SolderPackManifest.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 Jamie Mansfield <jmansfield@cadixdev.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SolderPackManifest.h"
+
+#include "Json.h"
+
+namespace TechnicSolder {
+
+void loadPack(Pack& v, QJsonObject& obj)
+{
+    v.recommended = Json::requireString(obj, "recommended");
+    v.latest = Json::requireString(obj, "latest");
+
+    auto builds = Json::requireArray(obj, "builds");
+    for (const auto buildRaw : builds) {
+        auto build = Json::requireValueString(buildRaw);
+        v.builds.append(build);
+    }
+}
+
+static void loadPackBuildMod(PackBuildMod& b, QJsonObject& obj)
+{
+    b.name = Json::requireString(obj, "name");
+    b.version = Json::requireString(obj, "version");
+    b.md5 = Json::requireString(obj, "md5");
+    b.url = Json::requireString(obj, "url");
+}
+
+void loadPackBuild(PackBuild& v, QJsonObject& obj)
+{
+    v.minecraft = Json::requireString(obj, "minecraft");
+
+    auto mods = Json::requireArray(obj, "mods");
+    for (const auto modRaw : mods) {
+        auto modObj = Json::requireValueObject(modRaw);
+        PackBuildMod mod;
+        loadPackBuildMod(mod, modObj);
+        v.mods.append(mod);
+    }
+}
+
+}

--- a/launcher/modplatform/technic/SolderPackManifest.h
+++ b/launcher/modplatform/technic/SolderPackManifest.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Jamie Mansfield <jmansfield@cadixdev.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <QString>
+#include <QVector>
+#include <QJsonObject>
+
+namespace TechnicSolder {
+
+struct Pack {
+    QString recommended;
+    QString latest;
+    QVector<QString> builds;
+};
+
+void loadPack(Pack& v, QJsonObject& obj);
+
+struct PackBuildMod {
+    QString name;
+    QString version;
+    QString md5;
+    QString url;
+};
+
+struct PackBuild {
+    QString minecraft;
+    QVector<PackBuildMod> mods;
+};
+
+void loadPackBuild(PackBuild& v, QJsonObject& obj);
+
+}

--- a/launcher/ui/pages/modplatform/technic/TechnicData.h
+++ b/launcher/ui/pages/modplatform/technic/TechnicData.h
@@ -36,6 +36,7 @@ struct Modpack {
     QString websiteUrl;
     QString author;
     QString description;
+    QString currentVersion;
 };
 }
 

--- a/launcher/ui/pages/modplatform/technic/TechnicData.h
+++ b/launcher/ui/pages/modplatform/technic/TechnicData.h
@@ -1,4 +1,5 @@
 /* Copyright 2020-2021 MultiMC Contributors
+ * Copyright 2021-2022 Jamie Mansfield <jmansfield@cadixdev.org>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +18,7 @@
 
 #include <QList>
 #include <QString>
+#include <QVector>
 
 namespace Technic {
 struct Modpack {
@@ -37,6 +39,10 @@ struct Modpack {
     QString author;
     QString description;
     QString currentVersion;
+
+    bool versionsLoaded = false;
+    QString recommended;
+    QVector<QString> versions;
 };
 }
 

--- a/launcher/ui/pages/modplatform/technic/TechnicModel.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicModel.cpp
@@ -16,6 +16,7 @@
 
 #include "TechnicModel.h"
 #include "Application.h"
+#include "BuildConfig.h"
 #include "Json.h"
 
 #include <QIcon>
@@ -95,21 +96,23 @@ void Technic::ListModel::performSearch()
     NetJob *netJob = new NetJob("Technic::Search", APPLICATION->network());
     QString searchUrl = "";
     if (currentSearchTerm.isEmpty()) {
-        searchUrl = "https://api.technicpack.net/trending?build=multimc";
+        searchUrl = QString("%1trending?build=%2")
+                .arg(BuildConfig.TECHNIC_API_BASE_URL, BuildConfig.TECHNIC_API_BUILD);
         searchMode = List;
     }
     else if (currentSearchTerm.startsWith("http://api.technicpack.net/modpack/")) {
-        searchUrl = QString("https://%1?build=multimc").arg(currentSearchTerm.mid(7));
+        searchUrl = QString("https://%1?build=%2")
+                .arg(currentSearchTerm.mid(7), BuildConfig.TECHNIC_API_BUILD);
         searchMode = Single;
     }
     else if (currentSearchTerm.startsWith("https://api.technicpack.net/modpack/")) {
-        searchUrl = QString("%1?build=multimc").arg(currentSearchTerm);
+        searchUrl = QString("%1?build=%2").arg(currentSearchTerm, BuildConfig.TECHNIC_API_BUILD);
         searchMode = Single;
     }
     else {
         searchUrl = QString(
-            "https://api.technicpack.net/search?build=multimc&q=%1"
-        ).arg(currentSearchTerm);
+            "%1search?build=%2&q=%3"
+        ).arg(BuildConfig.TECHNIC_API_BASE_URL, BuildConfig.TECHNIC_API_BUILD, currentSearchTerm);
         searchMode = List;
     }
     netJob->addNetAction(Net::Download::makeByteArray(QUrl(searchUrl), &response));

--- a/launcher/ui/pages/modplatform/technic/TechnicModel.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicModel.cpp
@@ -1,4 +1,5 @@
 /* Copyright 2020-2021 MultiMC Contributors
+ * Copyright 2021 Jamie Mansfield <jmansfield@cadixdev.org>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,12 +96,21 @@ void Technic::ListModel::performSearch()
     QString searchUrl = "";
     if (currentSearchTerm.isEmpty()) {
         searchUrl = "https://api.technicpack.net/trending?build=multimc";
+        searchMode = List;
     }
-    else
-    {
+    else if (currentSearchTerm.startsWith("http://api.technicpack.net/modpack/")) {
+        searchUrl = QString("https://%1?build=multimc").arg(currentSearchTerm.mid(7));
+        searchMode = Single;
+    }
+    else if (currentSearchTerm.startsWith("https://api.technicpack.net/modpack/")) {
+        searchUrl = QString("%1?build=multimc").arg(currentSearchTerm);
+        searchMode = Single;
+    }
+    else {
         searchUrl = QString(
             "https://api.technicpack.net/search?build=multimc&q=%1"
         ).arg(currentSearchTerm);
+        searchMode = List;
     }
     netJob->addNetAction(Net::Download::makeByteArray(QUrl(searchUrl), &response));
     jobPtr = netJob;
@@ -125,26 +135,58 @@ void Technic::ListModel::searchRequestFinished()
     QList<Modpack> newList;
     try {
         auto root = Json::requireObject(doc);
-        auto objs = Json::requireArray(root, "modpacks");
-        for (auto technicPack: objs) {
-            Modpack pack;
-            auto technicPackObject = Json::requireValueObject(technicPack);
-            pack.name = Json::requireString(technicPackObject, "name");
-            pack.slug = Json::requireString(technicPackObject, "slug");
-            if (pack.slug == "vanilla")
-                continue;
 
-            auto rawURL = Json::ensureString(technicPackObject, "iconUrl", "null");
-            if(rawURL == "null") {
-                pack.logoUrl = "null";
-                pack.logoName = "null";
+        switch (searchMode) {
+            case List: {
+                auto objs = Json::requireArray(root, "modpacks");
+                for (auto technicPack: objs) {
+                    Modpack pack;
+                    auto technicPackObject = Json::requireValueObject(technicPack);
+                    pack.name = Json::requireString(technicPackObject, "name");
+                    pack.slug = Json::requireString(technicPackObject, "slug");
+                    if (pack.slug == "vanilla")
+                        continue;
+
+                    auto rawURL = Json::ensureString(technicPackObject, "iconUrl", "null");
+                    if(rawURL == "null") {
+                        pack.logoUrl = "null";
+                        pack.logoName = "null";
+                    }
+                    else {
+                        pack.logoUrl = rawURL;
+                        pack.logoName = rawURL.section(QLatin1Char('/'), -1).section(QLatin1Char('.'), 0, 0);
+                    }
+                    pack.broken = false;
+                    newList.append(pack);
+                }
+                break;
             }
-            else {
-                pack.logoUrl = rawURL;
-                pack.logoName = rawURL.section(QLatin1Char('/'), -1).section(QLatin1Char('.'), 0, 0);
+            case Single: {
+                if (root.contains("error")) {
+                    // Invalid API url
+                    break;
+                }
+
+                Modpack pack;
+                pack.name = Json::requireString(root, "displayName");
+                pack.slug = Json::requireString(root, "name");
+
+                if (root.contains("icon")) {
+                    auto iconObj = Json::requireObject(root, "icon");
+                    auto iconUrl = Json::requireString(iconObj, "url");
+
+                    pack.logoUrl = iconUrl;
+                    pack.logoName = iconUrl.section(QLatin1Char('/'), -1).section(QLatin1Char('.'), 0, 0);
+                }
+                else {
+                    pack.logoUrl = "null";
+                    pack.logoName = "null";
+                }
+
+                pack.broken = false;
+                newList.append(pack);
+                break;
             }
-            pack.broken = false;
-            newList.append(pack);
         }
     }
     catch (const JSONValidationError &err)

--- a/launcher/ui/pages/modplatform/technic/TechnicModel.h
+++ b/launcher/ui/pages/modplatform/technic/TechnicModel.h
@@ -1,4 +1,5 @@
 /* Copyright 2020-2021 MultiMC Contributors
+ * Copyright 2021 Jamie Mansfield <jmansfield@cadixdev.org>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,6 +64,10 @@ private:
         ResetRequested,
         Finished
     } searchState = None;
+    enum SearchMode {
+        List,
+        Single,
+    } searchMode = List;
     NetJob::Ptr jobPtr;
     QByteArray response;
 };

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
@@ -184,7 +184,7 @@ void TechnicPage::metadataLoaded()
         text = "<a href=\"" + current.websiteUrl.toHtmlEscaped() + "\">" + name.toHtmlEscaped() + "</a>";
 
     if (!current.author.isEmpty()) {
-        text += tr(" by ") + current.author.toHtmlEscaped();
+        text += "<br>" + tr(" by ") + current.author.toHtmlEscaped();
     }
 
     text += "<br><br>";

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
@@ -1,4 +1,5 @@
 /* Copyright 2013-2022 MultiMC Contributors
+ * Copyright 2021-2022 Jamie Mansfield <jmansfield@cadixdev.org>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +25,7 @@
 #include "TechnicModel.h"
 #include "modplatform/technic/SingleZipPackInstallTask.h"
 #include "modplatform/technic/SolderPackInstallTask.h"
+#include "modplatform/technic/SolderPackManifest.h"
 #include "Json.h"
 
 #include "Application.h"
@@ -36,7 +38,9 @@ TechnicPage::TechnicPage(NewInstanceDialog* dialog, QWidget *parent)
     ui->searchEdit->installEventFilter(this);
     model = new Technic::ListModel(this);
     ui->packView->setModel(model);
+
     connect(ui->packView->selectionModel(), &QItemSelectionModel::currentChanged, this, &TechnicPage::onSelectionChanged);
+    connect(ui->versionSelectionBox, &QComboBox::currentTextChanged, this, &TechnicPage::onVersionSelectionChanged);
 }
 
 bool TechnicPage::eventFilter(QObject* watched, QEvent* event)
@@ -74,13 +78,14 @@ void TechnicPage::triggerSearch() {
 
 void TechnicPage::onSelectionChanged(QModelIndex first, QModelIndex second)
 {
+    ui->versionSelectionBox->clear();
+
     if(!first.isValid())
     {
         if(isOpened)
         {
             dialog->setSuggestedPack();
         }
-        //ui->frame->clear();
         return;
     }
 
@@ -113,17 +118,19 @@ void TechnicPage::suggestCurrent()
     }
 
     NetJob *netJob = new NetJob(QString("Technic::PackMeta(%1)").arg(current.name), APPLICATION->network());
-    std::shared_ptr<QByteArray> response = std::make_shared<QByteArray>();
     QString slug = current.slug;
-    netJob->addNetAction(Net::Download::makeByteArray(QString("https://api.technicpack.net/modpack/%1?build=multimc").arg(slug), response.get()));
-    QObject::connect(netJob, &NetJob::succeeded, this, [this, response, slug]
+    netJob->addNetAction(Net::Download::makeByteArray(QString("https://api.technicpack.net/modpack/%1?build=multimc").arg(slug), &response));
+    QObject::connect(netJob, &NetJob::succeeded, this, [this, slug]
     {
+        jobPtr.reset();
+
         if (current.slug != slug)
         {
             return;
         }
-        QJsonParseError parse_error;
-        QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
+
+        QJsonParseError parse_error {};
+        QJsonDocument doc = QJsonDocument::fromJson(response, &parse_error);
         QJsonObject obj = doc.object();
         if(parse_error.error != QJsonParseError::NoError)
         {
@@ -167,9 +174,12 @@ void TechnicPage::suggestCurrent()
         current.description = Json::ensureString(obj, "description", QString(), "__placeholder__");
         current.currentVersion = Json::ensureString(obj, "version", QString(), "__placeholder__");
         current.metadataLoaded = true;
+
         metadataLoaded();
     });
-    netJob->start();
+
+    jobPtr = netJob;
+    jobPtr->start();
 }
 
 // expects current.metadataLoaded to be true
@@ -190,13 +200,108 @@ void TechnicPage::metadataLoaded()
     text += "<br><br>";
 
     ui->packDescription->setHtml(text + current.description);
+
+    // Strip trailing forward-slashes from Solder URL's
+    if (current.isSolder) {
+        while (current.url.endsWith('/')) current.url.chop(1);
+    }
+
+    // Display versions from Solder
+    if (!current.isSolder) {
+        // If the pack isn't a Solder pack, it only has the single version
+        ui->versionSelectionBox->addItem(current.currentVersion);
+    }
+    else if (current.versionsLoaded) {
+        // reverse foreach, so that the newest versions are first
+        for (auto i = current.versions.size(); i--;) {
+            ui->versionSelectionBox->addItem(current.versions.at(i));
+        }
+        ui->versionSelectionBox->setCurrentText(current.recommended);
+    }
+    else {
+        // For now, until the versions are pulled from the Solder instance, display the current
+        // version so we can display something quicker
+        ui->versionSelectionBox->addItem(current.currentVersion);
+
+        auto* netJob = new NetJob(QString("Technic::SolderMeta(%1)").arg(current.name), APPLICATION->network());
+        auto url = QString("%1/modpack/%2").arg(current.url, current.slug);
+        netJob->addNetAction(Net::Download::makeByteArray(QUrl(url), &response));
+
+        QObject::connect(netJob, &NetJob::succeeded, this, &TechnicPage::onSolderLoaded);
+
+        jobPtr = netJob;
+        jobPtr->start();
+    }
+
+    selectVersion();
+}
+
+void TechnicPage::selectVersion() {
+    if (!isOpened) {
+        return;
+    }
+    if (current.broken) {
+        dialog->setSuggestedPack();
+        return;
+    }
+
     if (!current.isSolder)
     {
-        dialog->setSuggestedPack(current.name + " " + current.currentVersion, new Technic::SingleZipPackInstallTask(current.url, current.minecraftVersion));
+        dialog->setSuggestedPack(current.name + " " + selectedVersion, new Technic::SingleZipPackInstallTask(current.url, current.minecraftVersion));
     }
     else
     {
-        while (current.url.endsWith('/')) current.url.chop(1);
-        dialog->setSuggestedPack(current.name + " " + current.currentVersion, new Technic::SolderPackInstallTask(APPLICATION->network(), current.url + "/modpack/" + current.slug, current.minecraftVersion));
+        dialog->setSuggestedPack(current.name + " " + selectedVersion, new Technic::SolderPackInstallTask(APPLICATION->network(), current.url + "/modpack/" + current.slug, selectedVersion, current.minecraftVersion));
     }
+}
+
+void TechnicPage::onSolderLoaded() {
+    jobPtr.reset();
+
+    auto fallback = [this]() {
+        current.versionsLoaded = true;
+
+        current.versions.clear();
+        current.versions.append(current.currentVersion);
+    };
+
+    current.versions.clear();
+
+    QJsonParseError parse_error {};
+    auto doc = QJsonDocument::fromJson(response, &parse_error);
+    if (parse_error.error != QJsonParseError::NoError) {
+        qWarning() << "Error while parsing JSON response from Solder at " << parse_error.offset << " reason: " << parse_error.errorString();
+        qWarning() << response;
+        fallback();
+        return;
+    }
+    auto obj = doc.object();
+
+    TechnicSolder::Pack pack;
+    try {
+        TechnicSolder::loadPack(pack, obj);
+    }
+    catch (const JSONValidationError &err) {
+        qCritical() << "Couldn't parse Solder pack metadata:" << err.cause();
+        fallback();
+        return;
+    }
+
+    current.versionsLoaded = true;
+    current.recommended = pack.recommended;
+    current.versions.append(pack.builds);
+
+    // Finally, let's reload :)
+    ui->versionSelectionBox->clear();
+    metadataLoaded();
+}
+
+void TechnicPage::onVersionSelectionChanged(QString data) {
+    if (data.isNull() || data.isEmpty()) {
+        selectedVersion = "";
+        return;
+    }
+
+    selectedVersion = data;
+    selectVersion();
 }

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
@@ -22,6 +22,7 @@
 
 #include "ui/dialogs/NewInstanceDialog.h"
 
+#include "BuildConfig.h"
 #include "TechnicModel.h"
 #include "modplatform/technic/SingleZipPackInstallTask.h"
 #include "modplatform/technic/SolderPackInstallTask.h"
@@ -119,7 +120,7 @@ void TechnicPage::suggestCurrent()
 
     NetJob *netJob = new NetJob(QString("Technic::PackMeta(%1)").arg(current.name), APPLICATION->network());
     QString slug = current.slug;
-    netJob->addNetAction(Net::Download::makeByteArray(QString("https://api.technicpack.net/modpack/%1?build=multimc").arg(slug), &response));
+    netJob->addNetAction(Net::Download::makeByteArray(QString("%1modpack/%2?build=%3").arg(BuildConfig.TECHNIC_API_BASE_URL, slug, BuildConfig.TECHNIC_API_BUILD), &response));
     QObject::connect(netJob, &NetJob::succeeded, this, [this, slug]
     {
         jobPtr.reset();

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
@@ -178,14 +178,12 @@ void TechnicPage::metadataLoaded()
     QString name = current.name;
 
     if (current.websiteUrl.isEmpty())
-        // This allows injecting HTML here.
-        text = name;
+        text = name.toHtmlEscaped();
     else
-        // URL not properly escaped for inclusion in HTML. The name allows for injecting HTML.
-        text = "<a href=\"" + current.websiteUrl + "\">" + name + "</a>";
+        text = "<a href=\"" + current.websiteUrl.toHtmlEscaped() + "\">" + name.toHtmlEscaped() + "</a>";
+
     if (!current.author.isEmpty()) {
-        // This allows injecting HTML here
-        text += tr(" by ") + current.author;
+        text += tr(" by ") + current.author.toHtmlEscaped();
     }
 
     text += "<br><br>";

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
@@ -165,6 +165,7 @@ void TechnicPage::suggestCurrent()
         current.websiteUrl = Json::ensureString(obj, "platformUrl", QString(), "__placeholder__");
         current.author = Json::ensureString(obj, "user", QString(), "__placeholder__");
         current.description = Json::ensureString(obj, "description", QString(), "__placeholder__");
+        current.currentVersion = Json::ensureString(obj, "version", QString(), "__placeholder__");
         current.metadataLoaded = true;
         metadataLoaded();
     });
@@ -191,11 +192,11 @@ void TechnicPage::metadataLoaded()
     ui->packDescription->setHtml(text + current.description);
     if (!current.isSolder)
     {
-        dialog->setSuggestedPack(current.name, new Technic::SingleZipPackInstallTask(current.url, current.minecraftVersion));
+        dialog->setSuggestedPack(current.name + " " + current.currentVersion, new Technic::SingleZipPackInstallTask(current.url, current.minecraftVersion));
     }
     else
     {
         while (current.url.endsWith('/')) current.url.chop(1);
-        dialog->setSuggestedPack(current.name, new Technic::SolderPackInstallTask(APPLICATION->network(), current.url + "/modpack/" + current.slug, current.minecraftVersion));
+        dialog->setSuggestedPack(current.name + " " + current.currentVersion, new Technic::SolderPackInstallTask(APPLICATION->network(), current.url + "/modpack/" + current.slug, current.minecraftVersion));
     }
 }

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.h
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.h
@@ -1,4 +1,5 @@
 /* Copyright 2013-2021 MultiMC Contributors
+ * Copyright 2021-2022 Jamie Mansfield <jmansfield@cadixdev.org>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +20,7 @@
 
 #include "ui/pages/BasePage.h"
 #include <Application.h>
+#include "net/NetJob.h"
 #include "tasks/Task.h"
 #include "TechnicData.h"
 
@@ -65,14 +67,22 @@ public:
 private:
     void suggestCurrent();
     void metadataLoaded();
+    void selectVersion();
 
 private slots:
     void triggerSearch();
     void onSelectionChanged(QModelIndex first, QModelIndex second);
+    void onSolderLoaded();
+    void onVersionSelectionChanged(QString data);
 
 private:
     Ui::TechnicPage *ui = nullptr;
     NewInstanceDialog* dialog = nullptr;
     Technic::ListModel* model = nullptr;
+
     Technic::Modpack current;
+    QString selectedVersion;
+
+    NetJob::Ptr jobPtr;
+    QByteArray response;
 };

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.ui
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.ui
@@ -10,52 +10,44 @@
     <height>405</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <widget class="QWidget" name="widget" native="true">
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="QLineEdit" name="searchEdit">
-        <property name="placeholderText">
-         <string>Search and filter ...</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="searchButton">
-        <property name="text">
-         <string>Search</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <layout class="QGridLayout" name="gridLayout">
-     <property name="rightMargin">
-      <number>0</number>
-     </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="3" column="0" colspan="2">
+    <layout class="QGridLayout" name="gridLayout_3">
+     <item row="0" column="2">
+      <widget class="QComboBox" name="versionSelectionBox"/>
+     </item>
      <item row="0" column="1">
-      <widget class="QTextBrowser" name="packDescription"/>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Version selected:</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
      </item>
      <item row="0" column="0">
-      <widget class="QListView" name="packView">
-       <property name="horizontalScrollBarPolicy">
-        <enum>Qt::ScrollBarAlwaysOff</enum>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
        </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Preferred</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>1</width>
+         <height>1</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <layout class="QGridLayout" name="gridLayout_2">
+     <item row="0" column="0">
+      <widget class="QListView" name="packView">
        <property name="alternatingRowColors">
         <bool>true</bool>
        </property>
@@ -67,14 +59,27 @@
        </property>
       </widget>
      </item>
+     <item row="0" column="1">
+      <widget class="QTextBrowser" name="packDescription"/>
+     </item>
     </layout>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLineEdit" name="searchEdit">
+     <property name="placeholderText">
+      <string>Search and filter ...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QPushButton" name="searchButton">
+     <property name="text">
+      <string>Search</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>
- <tabstops>
-  <tabstop>searchEdit</tabstop>
-  <tabstop>searchButton</tabstop>
- </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
- Ability to use pack API urls in search to find packs
  - This allows private packs to be installed
- Modpack version is now included in the instance title
  - This matches patches I made to ATL + MCH
- The Technic pack description now more closely matches the CurseForge display
-  Solder packs will now display a list of available versions
   - Solder packs will also verify checksums of each file downloaded


<img width="908" alt="Screenshot 2022-10-20 at 16 48 39" src="https://user-images.githubusercontent.com/5103549/196996803-3959a0ca-eb9b-494b-9fa6-14e9c917a8c8.png">
