### PR TITLE
NOISSUE Add setting to display playtime in hours only

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -718,6 +718,7 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
         m_settings->registerSetting("ShowGameTime", true);
         m_settings->registerSetting("ShowGlobalGameTime", true);
         m_settings->registerSetting("RecordGameTime", true);
+        m_settings->registerSetting("ShowGameTimeHours", false);
 
         // Minecraft launch method
         m_settings->registerSetting("MCLaunchMethod", "LauncherPart");

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -785,11 +785,19 @@ QString MinecraftInstance::getStatusbarDescription()
     if(m_settings->get("ShowGameTime").toBool())
     {
         if (lastTimePlayed() > 0) {
-            description.append(tr(", last played for %1").arg(Time::prettifyDuration(lastTimePlayed())));
+            if (APPLICATION->settings()->get("ShowGameTimeHours").toBool()) {
+                description.append(tr(", last played for %1 hours").arg(lastTimePlayed() / 3600.0, 0, 'f', 2));
+            } else {
+                description.append(tr(", last played for %1").arg(Time::prettifyDuration(lastTimePlayed())));
+            }
         }
 
         if (totalTimePlayed() > 0) {
-            description.append(tr(", total played for %1").arg(Time::prettifyDuration(totalTimePlayed())));
+            if (APPLICATION->settings()->get("ShowGameTimeHours").toBool()) {
+                description.append(tr(", total played for %1 hours").arg(totalTimePlayed() / 3600.0, 0, 'f', 1));
+            } else {
+                description.append(tr(", total played for %1").arg(Time::prettifyDuration(totalTimePlayed())));
+            }
         }
     }
     if(hasCrashed())

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -2006,6 +2006,10 @@ void MainWindow::updateStatusCenter()
 
     int timePlayed = APPLICATION->instances()->getTotalPlayTime();
     if (timePlayed > 0) {
-        m_statusCenter->setText(tr("Total playtime: %1").arg(Time::prettifyDuration(timePlayed)));
+        if (APPLICATION->settings()->get("ShowGameTimeHours").toBool()) {
+            m_statusCenter->setText(tr("Total playtime: %1 hours").arg(timePlayed / 3600.0, 0, 'f', 1));
+        } else {
+            m_statusCenter->setText(tr("Total playtime: %1").arg(Time::prettifyDuration(timePlayed)));
+        }
     }
 }

--- a/launcher/ui/pages/global/MinecraftPage.cpp
+++ b/launcher/ui/pages/global/MinecraftPage.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 MultiMC Contributors
+/* Copyright 2013-2022 MultiMC Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,6 +71,7 @@ void MinecraftPage::applySettings()
     s->set("ShowGameTime", ui->showGameTime->isChecked());
     s->set("ShowGlobalGameTime", ui->showGlobalGameTime->isChecked());
     s->set("RecordGameTime", ui->recordGameTime->isChecked());
+    s->set("ShowGameTimeHours", ui->showGameTimeHours->isChecked());
 }
 
 void MinecraftPage::loadSettings()

--- a/launcher/ui/pages/global/MinecraftPage.ui
+++ b/launcher/ui/pages/global/MinecraftPage.ui
@@ -161,6 +161,13 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="showGameTimeHours">
+            <property name="text">
+             <string>Show time spent playing in hours only</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>


### PR DESCRIPTION
This feature has been requested a lot on Discord as other game launchers such as Steam display time in hours only.