### PR TITLE
GH-4978 Add button to log back in when account expired 

### DIFF
--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -121,8 +121,7 @@ void LaunchController::login() {
         m_session->wants_online = m_online;
         m_accountToUse->fillSession(m_session);
 
-        //switch(m_accountToUse->accountState()) {
-        switch (AccountState::Expired) {
+        switch(m_accountToUse->accountState()) {
             case AccountState::Offline: {
                 m_session->wants_online = false;
                 // NOTE: fallthrough is intentional
@@ -268,7 +267,8 @@ void LaunchController::login() {
                         if (isDefault) {
                             accounts->setDefaultAccount(newAccount);
                         }
-                        m_accountToUse = newAccount;
+                        decideAccount();
+                        continue;
                     } else {
                         emitFailed(tr("Account expired and re-login attempt failed"));
                         return;

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -250,6 +250,7 @@ void LaunchController::login() {
                                     ),
                                     QMessageBox::Warning
                             )->exec();
+                            emitFailed(tr("Attempted to re-login to a Microsoft account on an unsupported platform"));
                             return;
                         }
                         newAccount = MSALoginDialog::newAccount(

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -9,6 +9,8 @@
 #include "ui/dialogs/ProgressDialog.h"
 #include "ui/dialogs/EditAccountDialog.h"
 #include "ui/dialogs/ProfileSetupDialog.h"
+#include "ui/dialogs/LoginDialog.h"
+#include "ui/dialogs/MSALoginDialog.h"
 
 #include <QLineEdit>
 #include <QInputDialog>
@@ -119,7 +121,8 @@ void LaunchController::login() {
         m_session->wants_online = m_online;
         m_accountToUse->fillSession(m_session);
 
-        switch(m_accountToUse->accountState()) {
+        //switch(m_accountToUse->accountState()) {
+        switch (AccountState::Expired) {
             case AccountState::Offline: {
                 m_session->wants_online = false;
                 // NOTE: fallthrough is intentional
@@ -223,16 +226,57 @@ void LaunchController::login() {
             }
             */
             case AccountState::Expired: {
-                auto errorString = tr("The account has expired and needs to be logged into manually again.");
-                QMessageBox::warning(
+                auto errorString = tr("The account has expired and needs to be logged into manually. Press OK to log in again.");
+                auto button = QMessageBox::warning(
                     m_parentWidget,
                     tr("Account refresh failed"),
                     errorString,
-                    QMessageBox::StandardButton::Ok,
+                    QMessageBox::StandardButton::Ok | QMessageBox::StandardButton::Cancel,
                     QMessageBox::StandardButton::Ok
                 );
-                emitFailed(errorString);
-                return;
+                if (button == QMessageBox::StandardButton::Ok) {
+                    auto accounts = APPLICATION->accounts();
+                    bool isDefault = accounts->defaultAccount() == m_accountToUse;
+                    bool msa = m_accountToUse->isMSA();
+                    accounts->removeAccount(accounts->index(accounts->findAccountByProfileId(m_accountToUse->profileId())));
+                    MinecraftAccountPtr newAccount = nullptr;
+                    if (msa) {
+                        if(BuildConfig.BUILD_PLATFORM == "osx64") {
+                            CustomMessageBox::selectable(
+                                    m_parentWidget,
+                                    tr("Microsoft Accounts not available"),
+                                    tr(
+                                            "Microsoft accounts are only usable on macOS 10.13 or newer, with fully updated MultiMC.\n\n"
+                                            "Please update both your operating system and MultiMC."
+                                    ),
+                                    QMessageBox::Warning
+                            )->exec();
+                            return;
+                        }
+                        newAccount = MSALoginDialog::newAccount(
+                                m_parentWidget,
+                                tr("Please enter your Mojang account email and password to add your account.")
+                        );
+                    } else {
+                        newAccount = LoginDialog::newAccount(
+                                m_parentWidget,
+                                tr("Please enter your Mojang account email and password to add your account.")
+                        );
+                    }
+                    if (newAccount) {
+                        accounts->addAccount(newAccount);
+                        if (isDefault) {
+                            accounts->setDefaultAccount(newAccount);
+                        }
+                        m_accountToUse = newAccount;
+                    } else {
+                        emitFailed(tr("Account expired and re-login attempt failed"));
+                        return;
+                    }
+                } else {
+                    emitFailed(errorString);
+                    return;
+                }
             }
             case AccountState::Gone: {
                 auto errorString = tr("The account no longer exists on the servers. It may have been migrated, in which case please add the new account you migrated this one to.");


### PR DESCRIPTION
When the account is expired, pressing OK on the resulting dialog removes the account and opens the appropriate login dialog for the account type. Launching continues if an account is successfully added.
Fixes #4978 and #4982