### PR TITLE
Skin Allocating doesn't work

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,33 @@
-# MultiMC 0.6.16
+# MultiMC 0.7.0
+
+This is a nice big rollup release with all kinds of things that accumulated since the last release.
+
+With this, we are also abandoning the concept of stable releases. From now on, MultiMC will always use the `develop` channel.
+
+Some selected changes:
+
+- Remove concept of switching update channels
+- Improve path parsing for modrinth packs
+- GH-4978: Add button to log back in when the account has expired
+- GH-4964: Load ShowGameTimeHours setting correctly on settings page
+- Added a button to copy the MSA code
+- Added a setting to display playtime in hours only
+- GH-3516: Display available versions for Solder packs
+- Match CurseForge pack description format in Technic UI
+- Include the modpack version in instance title
+- Allow Technic pack API urls to be used in search
+- Improve ATLauncher modpack platform UI
+- Confirm screenshot upload
+- Improve Modrinth description's page rendering
+- Log file extension of mods to clear ambiguity
+- Shortcut creation has been added
+- Added log upload confirmation
+- Implement handling of client-overrides for Modrinth
+- GH-4724: Set suggested version for Modrinth packs when it is changed
+
+# Previous releases
+
+## MultiMC 0.6.16
 
 This brings some good and bad changes to modpack platforms, along with various fixes.
 
@@ -27,8 +56,6 @@ Aside from these changes, the release brings some general fixes.
     ```
     ./MultiMC --launch 1.17.1 --offline --name Steve
     ```
-
-# Previous releases
 
 ## MultiMC 0.6.15
 


### PR DESCRIPTION
In old MultiMC, there was an working skin in the stable versions, but now we have an skin allocating issue with the .png files in Minecraft, FIX is allocating the skin in the memory of the worlds (even though we might get an slightly larger world files in older versions, especially inf-20100531).