### PR TITLE
NOISSUE Fix directly joining servers on 23w14a and above

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -48,6 +48,7 @@
 #include "MinecraftLoadAndCheck.h"
 #include "minecraft/gameoptions/GameOptions.h"
 #include "minecraft/update/FoldersTask.h"
+#include "minecraft/VersionFilterData.h"
 
 #define IBUS "@im=ibus"
 
@@ -425,10 +426,17 @@ QStringList MinecraftInstance::processMinecraftArgs(
 
     if (serverToJoin && !serverToJoin->address.isEmpty())
     {
-        args_pattern += " --server " + serverToJoin->address;
-        args_pattern += " --port " + QString::number(serverToJoin->port);
+        if (m_components->getComponent("net.minecraft")->getReleaseDateTime() >= g_VersionFilterData.quickPlayBeginsDate)
+        {
+            args_pattern += " --quickPlayMultiplayer " + serverToJoin->address + ":" + QString::number(serverToJoin->port);
+        }
+        else
+        {
+            args_pattern += " --server " + serverToJoin->address;
+            args_pattern += " --port " + QString::number(serverToJoin->port);
+        }
     }
-
+    
     QMap<QString, QString> token_mapping;
     // yggdrasil!
     if(session) {
@@ -489,6 +497,7 @@ QString MinecraftInstance::createLaunchScript(AuthSessionPtr session, MinecraftS
 
     if (serverToJoin && !serverToJoin->address.isEmpty())
     {
+        launchScript += "useQuickPlay " + QString::number(m_components->getComponent("net.minecraft")->getReleaseDateTime() >= g_VersionFilterData.quickPlayBeginsDate) + "\n";
         launchScript += "serverAddress " + serverToJoin->address + "\n";
         launchScript += "serverPort " + QString::number(serverToJoin->port) + "\n";
     }

--- a/launcher/minecraft/VersionFilterData.cpp
+++ b/launcher/minecraft/VersionFilterData.cpp
@@ -66,7 +66,8 @@ VersionFilterData::VersionFilterData()
                       "net.java.jutils:jutils",     "org.lwjgl.lwjgl:lwjgl",
                       "org.lwjgl.lwjgl:lwjgl_util", "org.lwjgl.lwjgl:lwjgl-platform"};
 
-    java8BeginsDate  = timeFromS3Time("2017-03-30T09:32:19+00:00");
-    java16BeginsDate = timeFromS3Time("2021-05-12T11:19:15+00:00");
-    java17BeginsDate = timeFromS3Time("2021-11-16T17:04:48+00:00");
+    java8BeginsDate     = timeFromS3Time("2017-03-30T09:32:19+00:00");
+    java16BeginsDate    = timeFromS3Time("2021-05-12T11:19:15+00:00");
+    java17BeginsDate    = timeFromS3Time("2021-11-16T17:04:48+00:00");
+    quickPlayBeginsDate = timeFromS3Time("2023-04-05T12:05:17+00:00");
 }

--- a/launcher/minecraft/VersionFilterData.h
+++ b/launcher/minecraft/VersionFilterData.h
@@ -27,5 +27,7 @@ struct VersionFilterData
     QDateTime java16BeginsDate;
     // release data of first version to require Java 17 (1.18 Pre Release 2)
     QDateTime java17BeginsDate;
+    // release date of first version to use --quickPlayMultiplayer instead of --server/--port for directly joining servers
+    QDateTime quickPlayBeginsDate;
 };
 extern VersionFilterData g_VersionFilterData;

--- a/libraries/launcher/org/multimc/onesix/OneSixLauncher.java
+++ b/libraries/launcher/org/multimc/onesix/OneSixLauncher.java
@@ -1,4 +1,4 @@
-/* Copyright 2012-2021 MultiMC Contributors
+/* Copyright 2012-2023 MultiMC Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ public class OneSixLauncher implements Launcher
 
     private String serverAddress;
     private String serverPort;
+    private boolean useQuickPlay;
 
     // the much abused system classloader, for convenience (for further abuse)
     private ClassLoader cl;
@@ -80,6 +81,7 @@ public class OneSixLauncher implements Launcher
 
         serverAddress = params.firstSafe("serverAddress", null);
         serverPort = params.firstSafe("serverPort", null);
+        useQuickPlay = params.firstSafe("useQuickPlay").startsWith("1");
 
         cwd = System.getProperty("user.dir");
 
@@ -185,10 +187,18 @@ public class OneSixLauncher implements Launcher
 
         if (serverAddress != null)
         {
-            mcparams.add("--server");
-            mcparams.add(serverAddress);
-            mcparams.add("--port");
-            mcparams.add(serverPort);
+            if (useQuickPlay)
+            {
+                mcparams.add("--quickPlayMultiplayer");
+                mcparams.add(serverAddress + ":" + serverPort);
+            }
+            else
+            {
+                mcparams.add("--server");
+                mcparams.add(serverAddress);
+                mcparams.add("--port");
+                mcparams.add(serverPort);
+            }
         }
 
         // Get the Minecraft Class.


### PR DESCRIPTION
Minecraft 23w14a removed the `--server` and `--port` command line options and replaced them with a new `--quickPlayMultiplayer` option. This makes MultiMC pass the new option on instances with 23w14a and higher, fixing the `-s` command line flag, and shortcuts with the "join server on launch" option enabled, when launching these versions.