### PR TITLE
NOISSUE Add support for launching worlds directly via Quick Play

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -1197,6 +1197,7 @@ void Application::messageReceived(const QByteArray& message)
     {
         QString id = received.args["id"];
         QString server = received.args["server"];
+        QString world = received.args["world"];
         QString profile = received.args["profile"];
         bool offline = received.args["offline_enabled"] == "true";
         QString offlineName = received.args["offline_name"];
@@ -1214,9 +1215,11 @@ void Application::messageReceived(const QByteArray& message)
             return;
         }
 
-        QuickPlayTargetPtr serverObject = nullptr;
+        QuickPlayTargetPtr quickPlayTarget = nullptr;
         if(!server.isEmpty()) {
-            serverObject = std::make_shared<QuickPlayTarget>(QuickPlayTarget::parseMultiplayer(server));
+            quickPlayTarget = std::make_shared<QuickPlayTarget>(QuickPlayTarget::parseMultiplayer(server));
+        } else if(!world.isEmpty()) {
+            quickPlayTarget = std::make_shared<QuickPlayTarget>(QuickPlayTarget::parseSingleplayer(world));
         }
 
         MinecraftAccountPtr accountObject;
@@ -1232,7 +1235,7 @@ void Application::messageReceived(const QByteArray& message)
             instance,
             !offline,
             nullptr,
-            serverObject,
+            quickPlayTarget,
             accountObject,
             offlineName
         );

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -242,7 +242,11 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
         // --server
         parser.addOption("server");
         parser.addShortOpt("server", 's');
-        parser.addDocumentation("server", "Join the specified server on launch (only valid in combination with --launch)");
+        parser.addDocumentation("server", "Join the specified server on launch (only valid in combination with --launch, mutually exclusive with --world)");
+        // --world
+        parser.addOption("world");
+        parser.addShortOpt("world", 'w');
+        parser.addDocumentation("world", "Join the singleplayer world with the specified folder name on launch (only valid in combination with --launch, mutually exclusive with --server, only works with Minecraft 23w14a and later)");
         // --profile
         parser.addOption("profile");
         parser.addShortOpt("profile", 'a');
@@ -297,6 +301,7 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
     }
     m_instanceIdToLaunch = args["launch"].toString();
     m_serverToJoin = args["server"].toString();
+    m_worldToJoin = args["world"].toString();
     m_profileToUse = args["profile"].toString();
     if(args["offline"].toBool()) {
         m_offline = true;
@@ -367,11 +372,26 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
         return;
     }
 
+    // --world and --server can't be used together
+    if(!m_worldToJoin.isEmpty() && !m_serverToJoin.isEmpty())
+    {
+        std::cerr << "--server and --world are mutually exclusive!" << std::endl;
+        m_status = Application::Failed;
+        return;
+    }
+
     // all the things invalid when NOT trying to --launch
     if(m_instanceIdToLaunch.isEmpty()) {
         if(!m_serverToJoin.isEmpty())
         {
             std::cerr << "--server can only be used in combination with --launch!" << std::endl;
+            m_status = Application::Failed;
+            return;
+        }
+
+        if(!m_worldToJoin.isEmpty())
+        {
+            std::cerr << "--world can only be used in combination with --launch!" << std::endl;
             m_status = Application::Failed;
             return;
         }
@@ -507,6 +527,10 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
                 {
                     launch.args["server"] = m_serverToJoin;
                 }
+                if(!m_worldToJoin.isEmpty())
+                {
+                    launch.args["world"] = m_worldToJoin;
+                }
                 if(!m_profileToUse.isEmpty())
                 {
                     launch.args["profile"] = m_profileToUse;
@@ -598,6 +622,10 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
         if(!m_serverToJoin.isEmpty())
         {
             qDebug() << "Address of server to join  :" << m_serverToJoin;
+        }
+        if(!m_worldToJoin.isEmpty())
+        {
+            qDebug() << "Name of world to join      :" << m_worldToJoin;
         }
         qDebug() << "<> Paths set.";
     }
@@ -1070,7 +1098,7 @@ void Application::performMainStartupAction()
         auto inst = instances()->getInstanceById(m_instanceIdToLaunch);
         if(inst)
         {
-            MinecraftServerTargetPtr serverToJoin = nullptr;
+            QuickPlayTargetPtr serverOrWorldToJoin = nullptr;
             MinecraftAccountPtr accountToUse = nullptr;
             bool offline = m_offline;
 
@@ -1078,8 +1106,14 @@ void Application::performMainStartupAction()
             if(!m_serverToJoin.isEmpty())
             {
                 // FIXME: validate the server string
-                serverToJoin.reset(new MinecraftServerTarget(MinecraftServerTarget::parse(m_serverToJoin)));
+                serverOrWorldToJoin.reset(new QuickPlayTarget(QuickPlayTarget::parseMultiplayer(m_serverToJoin)));
                 qDebug() << "   Launching with server" << m_serverToJoin;
+            }
+
+            if(!m_worldToJoin.isEmpty())
+            {
+                serverOrWorldToJoin.reset(new QuickPlayTarget(QuickPlayTarget::parseSingleplayer(m_worldToJoin)));
+                qDebug() << "   Launching with world" << m_worldToJoin;
             }
 
             if(!m_profileToUse.isEmpty())
@@ -1091,7 +1125,7 @@ void Application::performMainStartupAction()
                 qDebug() << "   Launching with account" << m_profileToUse;
             }
 
-            launch(inst, !offline, nullptr, serverToJoin, accountToUse, m_offlineName);
+            launch(inst, !offline, nullptr, serverOrWorldToJoin, accountToUse, m_offlineName);
             return;
         }
     }
@@ -1180,9 +1214,9 @@ void Application::messageReceived(const QByteArray& message)
             return;
         }
 
-        MinecraftServerTargetPtr serverObject = nullptr;
+        QuickPlayTargetPtr serverObject = nullptr;
         if(!server.isEmpty()) {
-            serverObject = std::make_shared<MinecraftServerTarget>(MinecraftServerTarget::parse(server));
+            serverObject = std::make_shared<QuickPlayTarget>(QuickPlayTarget::parseMultiplayer(server));
         }
 
         MinecraftAccountPtr accountObject;
@@ -1297,7 +1331,7 @@ bool Application::launch(
         InstancePtr instance,
         bool online,
         BaseProfilerFactory *profiler,
-        MinecraftServerTargetPtr serverToJoin,
+        QuickPlayTargetPtr quickPlayTarget,
         MinecraftAccountPtr accountToUse,
         const QString& offlineName
 ) {
@@ -1321,7 +1355,7 @@ bool Application::launch(
         controller->setInstance(instance);
         controller->setOnline(online);
         controller->setProfiler(profiler);
-        controller->setServerToJoin(serverToJoin);
+        controller->setQuickPlayTarget(quickPlayTarget);
         controller->setAccountToUse(accountToUse);
         controller->setOfflineName(offlineName);
         if(window)

--- a/launcher/Application.h
+++ b/launcher/Application.h
@@ -11,7 +11,7 @@
 
 #include <BaseInstance.h>
 
-#include "minecraft/launch/MinecraftServerTarget.h"
+#include "minecraft/launch/QuickPlayTarget.h"
 
 class LaunchController;
 class LocalPeer;
@@ -150,12 +150,12 @@ signals:
 
 public slots:
     bool launch(
-        InstancePtr instance,
-        bool online = true,
-        BaseProfilerFactory *profiler = nullptr,
-        MinecraftServerTargetPtr serverToJoin = nullptr,
-        MinecraftAccountPtr accountToUse = nullptr,
-        const QString &offlineName = QString()
+            InstancePtr instance,
+            bool online = true,
+            BaseProfilerFactory *profiler = nullptr,
+            QuickPlayTargetPtr quickPlayTarget = nullptr,
+            MinecraftAccountPtr accountToUse = nullptr,
+            const QString &offlineName = QString()
     );
     bool kill(InstancePtr instance);
 
@@ -234,6 +234,7 @@ private:
 public:
     QString m_instanceIdToLaunch;
     QString m_serverToJoin;
+    QString m_worldToJoin;
     QString m_profileToUse;
     bool m_offline = false;
     QString m_offlineName;

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 MultiMC Contributors
+/* Copyright 2013-2023 MultiMC Contributors
  * Copyright 2022 Jamie Mansfield <jmansfield@cadixdev.org>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -33,7 +33,7 @@
 
 #include "net/Mode.h"
 
-#include "minecraft/launch/MinecraftServerTarget.h"
+#include "minecraft/launch/QuickPlayTarget.h"
 
 class QDir;
 class Task;
@@ -161,7 +161,7 @@ public:
 
     /// returns a valid launcher (task container)
     virtual shared_qobject_ptr<LaunchTask> createLaunchTask(
-            AuthSessionPtr account, MinecraftServerTargetPtr serverToJoin) = 0;
+            AuthSessionPtr account, QuickPlayTargetPtr quickPlayTarget) = 0;
 
     /// returns the current launch task (if any)
     shared_qobject_ptr<LaunchTask> getLaunchTask();
@@ -239,7 +239,7 @@ public:
     /**
      * 'print' a verbose description of the instance into a QStringList
      */
-    virtual QStringList verboseDescription(AuthSessionPtr session, MinecraftServerTargetPtr serverToJoin) = 0;
+    virtual QStringList verboseDescription(AuthSessionPtr session, QuickPlayTargetPtr quickPlayTarget) = 0;
 
     Status currentStatus() const;
 

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -269,8 +269,8 @@ set(MINECRAFT_SOURCES
     minecraft/launch/ExtractNatives.h
     minecraft/launch/LauncherPartLaunch.cpp
     minecraft/launch/LauncherPartLaunch.h
-    minecraft/launch/MinecraftServerTarget.cpp
-    minecraft/launch/MinecraftServerTarget.h
+    minecraft/launch/QuickPlayTarget.cpp
+    minecraft/launch/QuickPlayTarget.h
     minecraft/launch/PrintInstanceInfo.cpp
     minecraft/launch/PrintInstanceInfo.h
     minecraft/launch/ReconstructAssets.cpp

--- a/launcher/InstancePageProvider.h
+++ b/launcher/InstancePageProvider.h
@@ -45,7 +45,7 @@ public:
             values.append(new TexturePackPage(onesix.get()));
             values.append(new ShaderPackPage(onesix.get()));
             values.append(new NotesPage(onesix.get()));
-            values.append(new WorldListPage(onesix.get(), onesix->worldList()));
+            values.append(new WorldListPage(onesix, onesix->worldList()));
             values.append(new ServersPage(onesix));
             // values.append(new GameOptionsPage(onesix.get()));
             values.append(new ScreenshotsPage(FS::PathCombine(onesix->gameRoot(), "screenshots")));
@@ -56,7 +56,7 @@ public:
         {
             values.append(new LegacyUpgradePage(legacy));
             values.append(new NotesPage(legacy.get()));
-            values.append(new WorldListPage(legacy.get(), legacy->worldList()));
+            values.append(new WorldListPage(legacy, legacy->worldList()));
             values.append(new ScreenshotsPage(FS::PathCombine(legacy->gameRoot(), "screenshots")));
         }
         auto logMatcher = inst->getLogFileMatcher();

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -321,7 +321,7 @@ void LaunchController::launchInstance()
         return;
     }
 
-    m_launcher = m_instance->createLaunchTask(m_session, m_serverToJoin);
+    m_launcher = m_instance->createLaunchTask(m_session, m_quickPlayTarget);
     if (!m_launcher)
     {
         emitFailed(tr("Couldn't instantiate a launcher."));

--- a/launcher/LaunchController.h
+++ b/launcher/LaunchController.h
@@ -3,7 +3,7 @@
 #include <BaseInstance.h>
 #include <tools/BaseProfiler.h>
 
-#include "minecraft/launch/MinecraftServerTarget.h"
+#include "minecraft/launch/QuickPlayTarget.h"
 #include "minecraft/auth/MinecraftAccount.h"
 
 class InstanceWindow;
@@ -40,8 +40,8 @@ public:
         m_parentWidget = widget;
     }
 
-    void setServerToJoin(MinecraftServerTargetPtr serverToJoin) {
-        m_serverToJoin = std::move(serverToJoin);
+    void setQuickPlayTarget(QuickPlayTargetPtr quickPlayTarget) {
+        m_quickPlayTarget = std::move(quickPlayTarget);
     }
 
     void setAccountToUse(MinecraftAccountPtr accountToUse) {
@@ -77,5 +77,5 @@ private:
     MinecraftAccountPtr m_accountToUse = nullptr;
     AuthSessionPtr m_session;
     shared_qobject_ptr<LaunchTask> m_launcher;
-    MinecraftServerTargetPtr m_serverToJoin;
+    QuickPlayTargetPtr m_quickPlayTarget;
 };

--- a/launcher/NullInstance.h
+++ b/launcher/NullInstance.h
@@ -27,7 +27,7 @@ public:
     {
         return instanceRoot();
     };
-    shared_qobject_ptr<LaunchTask> createLaunchTask(AuthSessionPtr, MinecraftServerTargetPtr) override
+    shared_qobject_ptr<LaunchTask> createLaunchTask(AuthSessionPtr, QuickPlayTargetPtr) override
     {
         return nullptr;
     }
@@ -67,7 +67,7 @@ public:
     {
         return false;
     }
-    QStringList verboseDescription(AuthSessionPtr session, MinecraftServerTargetPtr serverToJoin) override
+    QStringList verboseDescription(AuthSessionPtr session, QuickPlayTargetPtr quickPlayTarget) override
     {
         QStringList out;
         out << "Null instance - placeholder.";

--- a/launcher/launch/steps/LookupServerAddress.cpp
+++ b/launcher/launch/steps/LookupServerAddress.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 MultiMC Contributors
+/* Copyright 2013-2023 MultiMC Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/launch/steps/LookupServerAddress.cpp
+++ b/launcher/launch/steps/LookupServerAddress.cpp
@@ -32,7 +32,7 @@ void LookupServerAddress::setLookupAddress(const QString &lookupAddress)
     m_dnsLookup->setName(QString("_minecraft._tcp.%1").arg(lookupAddress));
 }
 
-void LookupServerAddress::setOutputAddressPtr(MinecraftServerTargetPtr output)
+void LookupServerAddress::setOutputAddressPtr(QuickPlayTargetPtr output)
 {
     m_output = std::move(output);
 }

--- a/launcher/launch/steps/LookupServerAddress.h
+++ b/launcher/launch/steps/LookupServerAddress.h
@@ -19,7 +19,7 @@
 #include <QObjectPtr.h>
 #include <QDnsLookup>
 
-#include "minecraft/launch/MinecraftServerTarget.h"
+#include "minecraft/launch/QuickPlayTarget.h"
 
 class LookupServerAddress: public LaunchStep {
 Q_OBJECT
@@ -35,7 +35,7 @@ public:
     }
 
     void setLookupAddress(const QString &lookupAddress);
-    void setOutputAddressPtr(MinecraftServerTargetPtr output);
+    void setOutputAddressPtr(QuickPlayTargetPtr output);
 
 private slots:
     void on_dnsLookupFinished();
@@ -45,5 +45,5 @@ private:
 
     QDnsLookup *m_dnsLookup;
     QString m_lookupAddress;
-    MinecraftServerTargetPtr m_output;
+    QuickPlayTargetPtr m_output;
 };

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -440,7 +440,7 @@ QStringList MinecraftInstance::processMinecraftArgs(
         }
     }
 
-    if (quickPlayTarget && quickPlayTarget->world.isEmpty())
+    if (quickPlayTarget && !quickPlayTarget->world.isEmpty())
     {
         args_pattern += " --quickPlaySingleplayer \"" + quickPlayTarget->world + "\"";
     }

--- a/launcher/minecraft/MinecraftInstance.h
+++ b/launcher/minecraft/MinecraftInstance.h
@@ -4,7 +4,7 @@
 #include "minecraft/mod/Mod.h"
 #include <QProcess>
 #include <QDir>
-#include "minecraft/launch/MinecraftServerTarget.h"
+#include "minecraft/launch/QuickPlayTarget.h"
 
 class ModFolderModel;
 class WorldList;
@@ -78,11 +78,11 @@ public:
 
     //////  Launch stuff //////
     Task::Ptr createUpdateTask(Net::Mode mode) override;
-    shared_qobject_ptr<LaunchTask> createLaunchTask(AuthSessionPtr account, MinecraftServerTargetPtr serverToJoin) override;
+    shared_qobject_ptr<LaunchTask> createLaunchTask(AuthSessionPtr account, QuickPlayTargetPtr quickPlayTarget) override;
     QStringList extraArguments() const override;
-    QStringList verboseDescription(AuthSessionPtr session, MinecraftServerTargetPtr serverToJoin) override;
+    QStringList verboseDescription(AuthSessionPtr session, QuickPlayTargetPtr quickPlayTarget) override;
     QList<Mod> getJarMods() const;
-    QString createLaunchScript(AuthSessionPtr session, MinecraftServerTargetPtr serverToJoin);
+    QString createLaunchScript(AuthSessionPtr session, QuickPlayTargetPtr quickPlayTarget);
     /// get arguments passed to java
     QStringList javaArguments() const;
 
@@ -109,7 +109,7 @@ public:
     virtual QString getMainClass() const;
 
     // FIXME: remove
-    virtual QStringList processMinecraftArgs(AuthSessionPtr account, MinecraftServerTargetPtr serverToJoin) const;
+    virtual QStringList processMinecraftArgs(AuthSessionPtr account, QuickPlayTargetPtr quickPlayTarget) const;
 
     virtual JavaVersion getJavaVersion() const;
 

--- a/launcher/minecraft/launch/DirectJavaLaunch.cpp
+++ b/launcher/minecraft/launch/DirectJavaLaunch.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 MultiMC Contributors
+/* Copyright 2013-2023 MultiMC Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/minecraft/launch/DirectJavaLaunch.cpp
+++ b/launcher/minecraft/launch/DirectJavaLaunch.cpp
@@ -55,7 +55,7 @@ void DirectJavaLaunch::executeTask()
     // make detachable - this will keep the process running even if the object is destroyed
     m_process.setDetachable(true);
 
-    auto mcArgs = minecraftInstance->processMinecraftArgs(m_session, m_serverToJoin);
+    auto mcArgs = minecraftInstance->processMinecraftArgs(m_session, m_quickPlayTarget);
     args.append(mcArgs);
 
     QString wrapperCommandStr = instance->getWrapperCommand().trimmed();

--- a/launcher/minecraft/launch/DirectJavaLaunch.h
+++ b/launcher/minecraft/launch/DirectJavaLaunch.h
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 MultiMC Contributors
+/* Copyright 2013-2023 MultiMC Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/minecraft/launch/DirectJavaLaunch.h
+++ b/launcher/minecraft/launch/DirectJavaLaunch.h
@@ -19,7 +19,7 @@
 #include <LoggedProcess.h>
 #include <minecraft/auth/AuthSession.h>
 
-#include "MinecraftServerTarget.h"
+#include "QuickPlayTarget.h"
 
 class DirectJavaLaunch: public LaunchStep
 {
@@ -41,9 +41,9 @@ public:
         m_session = session;
     }
 
-    void setServerToJoin(MinecraftServerTargetPtr serverToJoin)
+    void setQuickPlayTarget(QuickPlayTargetPtr quickPlayTarget)
     {
-        m_serverToJoin = std::move(serverToJoin);
+        m_quickPlayTarget = std::move(quickPlayTarget);
     }
 
 private slots:
@@ -53,6 +53,6 @@ private:
     LoggedProcess m_process;
     QString m_command;
     AuthSessionPtr m_session;
-    MinecraftServerTargetPtr m_serverToJoin;
+    QuickPlayTargetPtr m_quickPlayTarget;
 };
 

--- a/launcher/minecraft/launch/LauncherPartLaunch.cpp
+++ b/launcher/minecraft/launch/LauncherPartLaunch.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 MultiMC Contributors
+/* Copyright 2013-2023 MultiMC Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/minecraft/launch/LauncherPartLaunch.cpp
+++ b/launcher/minecraft/launch/LauncherPartLaunch.cpp
@@ -60,7 +60,7 @@ void LauncherPartLaunch::executeTask()
     auto instance = m_parent->instance();
     std::shared_ptr<MinecraftInstance> minecraftInstance = std::dynamic_pointer_cast<MinecraftInstance>(instance);
 
-    m_launchScript = minecraftInstance->createLaunchScript(m_session, m_serverToJoin);
+    m_launchScript = minecraftInstance->createLaunchScript(m_session, m_quickPlayTarget);
     QStringList args = minecraftInstance->javaArguments();
     QString allArgs = args.join(", ");
     emit logLine("Java Arguments:\n[" + m_parent->censorPrivateInfo(allArgs) + "]\n\n", MessageLevel::Launcher);

--- a/launcher/minecraft/launch/LauncherPartLaunch.h
+++ b/launcher/minecraft/launch/LauncherPartLaunch.h
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 MultiMC Contributors
+/* Copyright 2013-2023 MultiMC Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/minecraft/launch/LauncherPartLaunch.h
+++ b/launcher/minecraft/launch/LauncherPartLaunch.h
@@ -19,7 +19,7 @@
 #include <LoggedProcess.h>
 #include <minecraft/auth/AuthSession.h>
 
-#include "MinecraftServerTarget.h"
+#include "QuickPlayTarget.h"
 
 class LauncherPartLaunch: public LaunchStep
 {
@@ -41,9 +41,9 @@ public:
         m_session = session;
     }
 
-    void setServerToJoin(MinecraftServerTargetPtr serverToJoin)
+    void setQuickPlayTarget(QuickPlayTargetPtr quickPlayTarget)
     {
-        m_serverToJoin = std::move(serverToJoin);
+        m_quickPlayTarget = std::move(quickPlayTarget);
     }
 
 private slots:
@@ -54,7 +54,7 @@ private:
     QString m_command;
     AuthSessionPtr m_session;
     QString m_launchScript;
-    MinecraftServerTargetPtr m_serverToJoin;
+    QuickPlayTargetPtr m_quickPlayTarget;
 
     bool mayProceed = false;
 };

--- a/launcher/minecraft/launch/PrintInstanceInfo.cpp
+++ b/launcher/minecraft/launch/PrintInstanceInfo.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 MultiMC Contributors
+/* Copyright 2013-2023 MultiMC Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/minecraft/launch/PrintInstanceInfo.cpp
+++ b/launcher/minecraft/launch/PrintInstanceInfo.cpp
@@ -142,6 +142,6 @@ void PrintInstanceInfo::executeTask()
 #endif
 
     logLines(log, MessageLevel::Launcher);
-    logLines(instance->verboseDescription(m_session, m_serverToJoin), MessageLevel::Launcher);
+    logLines(instance->verboseDescription(m_session, m_quickPlayTarget), MessageLevel::Launcher);
     emitSucceeded();
 }

--- a/launcher/minecraft/launch/PrintInstanceInfo.h
+++ b/launcher/minecraft/launch/PrintInstanceInfo.h
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 MultiMC Contributors
+/* Copyright 2013-2023 MultiMC Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/minecraft/launch/PrintInstanceInfo.h
+++ b/launcher/minecraft/launch/PrintInstanceInfo.h
@@ -18,15 +18,15 @@
 #include <launch/LaunchStep.h>
 #include <memory>
 #include "minecraft/auth/AuthSession.h"
-#include "minecraft/launch/MinecraftServerTarget.h"
+#include "minecraft/launch/QuickPlayTarget.h"
 
 // FIXME: temporary wrapper for existing task.
 class PrintInstanceInfo: public LaunchStep
 {
     Q_OBJECT
 public:
-    explicit PrintInstanceInfo(LaunchTask *parent, AuthSessionPtr session, MinecraftServerTargetPtr serverToJoin) :
-        LaunchStep(parent), m_session(session), m_serverToJoin(serverToJoin) {};
+    explicit PrintInstanceInfo(LaunchTask *parent, AuthSessionPtr session, QuickPlayTargetPtr quickPlayTarget) :
+        LaunchStep(parent), m_session(session), m_quickPlayTarget(quickPlayTarget) {};
     virtual ~PrintInstanceInfo(){};
 
     virtual void executeTask();
@@ -36,6 +36,6 @@ public:
     }
 private:
     AuthSessionPtr m_session;
-    MinecraftServerTargetPtr m_serverToJoin;
+    QuickPlayTargetPtr m_quickPlayTarget;
 };
 

--- a/launcher/minecraft/launch/QuickPlayTarget.cpp
+++ b/launcher/minecraft/launch/QuickPlayTarget.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 MultiMC Contributors
+/* Copyright 2013-2023 MultiMC Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/minecraft/launch/QuickPlayTarget.cpp
+++ b/launcher/minecraft/launch/QuickPlayTarget.cpp
@@ -13,12 +13,12 @@
  * limitations under the License.
  */
 
-#include "MinecraftServerTarget.h"
+#include "QuickPlayTarget.h"
 
 #include <QStringList>
 
 // FIXME: the way this is written, it can't ever do any sort of validation and can accept total junk
-MinecraftServerTarget MinecraftServerTarget::parse(const QString &fullAddress) {
+QuickPlayTarget QuickPlayTarget::parseMultiplayer(const QString &fullAddress) {
     QStringList split = fullAddress.split(":");
 
     // The logic below replicates the exact logic minecraft uses for parsing server addresses.
@@ -63,5 +63,12 @@ MinecraftServerTarget MinecraftServerTarget::parse(const QString &fullAddress) {
         }
     }
 
-    return MinecraftServerTarget { realAddress, realPort };
+    return QuickPlayTarget {realAddress, realPort };
+}
+
+QuickPlayTarget QuickPlayTarget::parseSingleplayer(const QString &worldName)
+{
+    QuickPlayTarget target;
+    target.world = worldName;
+    return target;
 }

--- a/launcher/minecraft/launch/QuickPlayTarget.cpp
+++ b/launcher/minecraft/launch/QuickPlayTarget.cpp
@@ -63,7 +63,7 @@ QuickPlayTarget QuickPlayTarget::parseMultiplayer(const QString &fullAddress) {
         }
     }
 
-    return QuickPlayTarget {realAddress, realPort };
+    return QuickPlayTarget { realAddress, realPort };
 }
 
 QuickPlayTarget QuickPlayTarget::parseSingleplayer(const QString &worldName)

--- a/launcher/minecraft/launch/QuickPlayTarget.h
+++ b/launcher/minecraft/launch/QuickPlayTarget.h
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 MultiMC Contributors
+/* Copyright 2013-2023 MultiMC Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/minecraft/launch/QuickPlayTarget.h
+++ b/launcher/minecraft/launch/QuickPlayTarget.h
@@ -19,11 +19,16 @@
 
 #include <QString>
 
-struct MinecraftServerTarget {
+struct QuickPlayTarget {
+    // Multiplayer
     QString address;
     quint16 port;
 
-    static MinecraftServerTarget parse(const QString &fullAddress);
+    // Singleplayer
+    QString world;
+
+    static QuickPlayTarget parseMultiplayer(const QString &fullAddress);
+    static QuickPlayTarget parseSingleplayer(const QString &worldName);
 };
 
-typedef std::shared_ptr<MinecraftServerTarget> MinecraftServerTargetPtr;
+typedef std::shared_ptr<QuickPlayTarget> QuickPlayTargetPtr;

--- a/launcher/minecraft/legacy/LegacyInstance.cpp
+++ b/launcher/minecraft/legacy/LegacyInstance.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 MultiMC Contributors
+/* Copyright 2013-2023 MultiMC Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/minecraft/legacy/LegacyInstance.cpp
+++ b/launcher/minecraft/legacy/LegacyInstance.cpp
@@ -225,7 +225,7 @@ QString LegacyInstance::getStatusbarDescription()
     return tr("Instance from previous versions.");
 }
 
-QStringList LegacyInstance::verboseDescription(AuthSessionPtr session, MinecraftServerTargetPtr serverToJoin)
+QStringList LegacyInstance::verboseDescription(AuthSessionPtr session, QuickPlayTargetPtr quickPlayTarget)
 {
     QStringList out;
 

--- a/launcher/minecraft/legacy/LegacyInstance.h
+++ b/launcher/minecraft/legacy/LegacyInstance.h
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 MultiMC Contributors
+/* Copyright 2013-2023 MultiMC Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/minecraft/legacy/LegacyInstance.h
+++ b/launcher/minecraft/legacy/LegacyInstance.h
@@ -112,7 +112,7 @@ public:
         return false;
     }
     shared_qobject_ptr<LaunchTask> createLaunchTask(
-            AuthSessionPtr account, MinecraftServerTargetPtr serverToJoin) override
+            AuthSessionPtr account, QuickPlayTargetPtr quickPlayTarget) override
     {
         return nullptr;
     }
@@ -126,7 +126,7 @@ public:
     }
 
     QString getStatusbarDescription() override;
-    QStringList verboseDescription(AuthSessionPtr session, MinecraftServerTargetPtr serverToJoin) override;
+    QStringList verboseDescription(AuthSessionPtr session, QuickPlayTargetPtr quickPlayTarget) override;
 
     QProcessEnvironment createEnvironment() override
     {

--- a/launcher/ui/dialogs/CreateShortcutDialog.ui
+++ b/launcher/ui/dialogs/CreateShortcutDialog.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- Copyright 2022 arthomnix
+ Copyright 2022-2023 arthomnix
  This source is subject to the Microsoft Public License (MS-PL).
  Please see the COPYING.md file for more information.
 -->
@@ -12,7 +12,7 @@
     <x>0</x>
     <y>0</y>
     <width>796</width>
-    <height>232</height>
+    <height>330</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -30,17 +30,82 @@
      <property name="sizeConstraint">
       <enum>QLayout::SetDefaultConstraint</enum>
      </property>
-     <item row="3" column="0">
+     <item row="0" column="0">
+      <widget class="QLabel" name="shortcutPathLabel">
+       <property name="text">
+        <string>Shortcut path:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QCheckBox" name="useProfileCheckBox">
+       <property name="text">
+        <string>Use specific profile:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QComboBox" name="joinSingleplayer">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
       <widget class="QCheckBox" name="launchOfflineCheckBox">
        <property name="text">
         <string>Launch in offline mode</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="shortcutPathLabel">
+     <item row="6" column="1">
+      <widget class="QLineEdit" name="offlineUsername">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QCheckBox" name="joinWorldCheckBox">
        <property name="text">
-        <string>Shortcut path:</string>
+        <string>Join world on launch:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="joinServer">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QComboBox" name="profileComboBox">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="shortcutPath"/>
+     </item>
+     <item row="6" column="0">
+      <widget class="QCheckBox" name="offlineUsernameCheckBox">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Set offline mode username:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QRadioButton" name="joinSingleplayerRadioButton">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Singleplayer world:</string>
        </property>
       </widget>
      </item>
@@ -51,38 +116,15 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="1">
-      <widget class="QLineEdit" name="shortcutPath"/>
-     </item>
-     <item row="2" column="1">
-      <widget class="QComboBox" name="profileComboBox"/>
-     </item>
-     <item row="4" column="1">
-      <widget class="QLineEdit" name="offlineUsername"/>
-     </item>
-     <item row="4" column="0">
-      <widget class="QCheckBox" name="offlineUsernameCheckBox">
-       <property name="text">
-        <string>Set offline mode username:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QCheckBox" name="joinServerCheckBox">
-       <property name="text">
-        <string>Join server on launch:</string>
-       </property>
-      </widget>
-     </item>
      <item row="2" column="0">
-      <widget class="QCheckBox" name="useProfileCheckBox">
+      <widget class="QRadioButton" name="joinServerRadioButton">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
        <property name="text">
-        <string>Use specific profile:</string>
+        <string>Server address:</string>
        </property>
       </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="joinServer"/>
      </item>
     </layout>
    </item>
@@ -173,18 +215,18 @@
    </hints>
   </connection>
   <connection>
-   <sender>joinServerCheckBox</sender>
-   <signal>stateChanged(int)</signal>
-   <receiver>CreateShortcutDialog</receiver>
-   <slot>updateDialogState()</slot>
+   <sender>joinWorldCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>joinServerRadioButton</receiver>
+   <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>122</x>
      <y>61</y>
     </hint>
     <hint type="destinationlabel">
-     <x>397</x>
-     <y>114</y>
+     <x>140</x>
+     <y>93</y>
     </hint>
    </hints>
   </connection>
@@ -284,5 +326,136 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>joinWorldCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>joinSingleplayerRadioButton</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>140</x>
+     <y>59</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>140</x>
+     <y>132</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>joinServerRadioButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>joinServer</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>140</x>
+     <y>93</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>489</x>
+     <y>93</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>joinSingleplayerRadioButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>joinSingleplayer</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>140</x>
+     <y>132</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>489</x>
+     <y>132</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>useProfileCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>profileComboBox</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>140</x>
+     <y>171</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>489</x>
+     <y>171</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>launchOfflineCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>offlineUsernameCheckBox</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>140</x>
+     <y>205</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>140</x>
+     <y>239</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>joinSingleplayer</sender>
+   <signal>currentTextChanged(QString)</signal>
+   <receiver>CreateShortcutDialog</receiver>
+   <slot>updateDialogState()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>489</x>
+     <y>132</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>397</x>
+     <y>164</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>joinServerRadioButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>CreateShortcutDialog</receiver>
+   <slot>updateDialogState()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>140</x>
+     <y>93</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>397</x>
+     <y>164</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>joinSingleplayerRadioButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>CreateShortcutDialog</receiver>
+   <slot>updateDialogState()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>140</x>
+     <y>132</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>397</x>
+     <y>164</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
+ <slots>
+  <slot>updateDialogState()</slot>
+ </slots>
 </ui>

--- a/launcher/ui/pages/instance/InstanceSettingsPage.h
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.h
@@ -1,4 +1,4 @@
-/* Copyright 2013-2021 MultiMC Contributors
+/* Copyright 2013-2023 MultiMC Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/ui/pages/instance/InstanceSettingsPage.h
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.h
@@ -22,6 +22,7 @@
 #include <QObjectPtr.h>
 #include "ui/pages/BasePage.h"
 #include "JavaCommon.h"
+#include "minecraft/WorldList.h"
 #include "Application.h"
 
 class JavaChecker;
@@ -60,6 +61,8 @@ private slots:
     void on_javaDetectBtn_clicked();
     void on_javaTestBtn_clicked();
     void on_javaBrowseBtn_clicked();
+    void on_serverAddressRadioButton_toggled(bool checked);
+    void on_worldRadioButton_toggled(bool checked);
 
     void applySettings();
     void loadSettings();

--- a/launcher/ui/pages/instance/InstanceSettingsPage.ui
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.ui
@@ -39,7 +39,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>4</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="minecraftTab">
       <attribute name="title">

--- a/launcher/ui/pages/instance/InstanceSettingsPage.ui
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.ui
@@ -39,7 +39,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>4</number>
      </property>
      <widget class="QWidget" name="minecraftTab">
       <attribute name="title">
@@ -454,9 +454,9 @@
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="serverJoinGroupBox">
+        <widget class="QGroupBox" name="quickPlayGroupBox">
          <property name="title">
-          <string>Set a server to join on launch</string>
+          <string>Set a world to join on launch</string>
          </property>
          <property name="checkable">
           <bool>true</bool>
@@ -466,15 +466,9 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_11">
           <item>
-           <layout class="QGridLayout" name="serverJoinLayout">
+           <layout class="QGridLayout" name="quickPlayLayout">
             <item row="0" column="0">
-             <widget class="QLabel" name="serverJoinAddressLabel">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
+             <widget class="QRadioButton" name="serverAddressRadioButton">
               <property name="text">
                <string>Server address:</string>
               </property>
@@ -482,6 +476,16 @@
             </item>
             <item row="0" column="1">
              <widget class="QLineEdit" name="serverJoinAddress"/>
+            </item>
+            <item row="1" column="0">
+             <widget class="QRadioButton" name="worldRadioButton">
+              <property name="text">
+               <string>Singleplayer world:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QComboBox" name="worldsComboBox"/>
             </item>
            </layout>
           </item>

--- a/launcher/ui/pages/instance/ServersPage.cpp
+++ b/launcher/ui/pages/instance/ServersPage.cpp
@@ -762,7 +762,8 @@ void ServersPage::on_actionMove_Down_triggered()
 void ServersPage::on_actionJoin_triggered()
 {
     const auto &address = m_model->at(currentServer)->m_address;
-    APPLICATION->launch(m_inst, true, nullptr, std::make_shared<MinecraftServerTarget>(MinecraftServerTarget::parse(address)));
+    APPLICATION->launch(m_inst, true, nullptr, std::make_shared<QuickPlayTarget>(
+            QuickPlayTarget::parseMultiplayer(address)));
 }
 
 #include "ServersPage.moc"

--- a/launcher/ui/pages/instance/WorldListPage.cpp
+++ b/launcher/ui/pages/instance/WorldListPage.cpp
@@ -320,12 +320,6 @@ void WorldListPage::worldChanged(const QModelIndex &current, const QModelIndex &
     bool enable = index.isValid();
     ui->actionJoin->setVisible(enableJoinActions);
     ui->actionJoinOffline->setVisible(enableJoinActions);
-    // The above lines will only hide the actions from the right click menu, to hide them from the toolbar we need to do this.
-    // If any more actions are added above the Join/Join Offline actions, these indices will need to be updated!
-    ui->toolBar->actions().at(2)->setVisible(enableJoinActions);
-    ui->toolBar->actions().at(3)->setVisible(enableJoinActions);
-    // Also disable the separator so there aren't 2 separators in a row
-    ui->toolBar->actions().at(4)->setVisible(enableJoinActions);
     ui->actionJoin->setEnabled(enable && enableJoinActions);
     ui->actionJoinOffline->setEnabled(enable && enableJoinActions);
     ui->actionCopy_Seed->setEnabled(enable);

--- a/launcher/ui/pages/instance/WorldListPage.cpp
+++ b/launcher/ui/pages/instance/WorldListPage.cpp
@@ -24,13 +24,15 @@
 #include <QMessageBox>
 #include <QTreeView>
 #include <QInputDialog>
-#include <QProcess>
 
 #include "tools/MCEditTool.h"
 #include "FileSystem.h"
 
 #include "ui/GuiUtil.h"
 #include "DesktopServices.h"
+
+#include "minecraft/PackProfile.h"
+#include "minecraft/VersionFilterData.h"
 
 #include "Application.h"
 
@@ -62,7 +64,7 @@ public:
 };
 
 
-WorldListPage::WorldListPage(BaseInstance *inst, std::shared_ptr<WorldList> worlds, QWidget *parent)
+WorldListPage::WorldListPage(InstancePtr inst, std::shared_ptr<WorldList> worlds, QWidget *parent)
     : QMainWindow(parent), m_inst(inst), ui(new Ui::WorldListPage), m_worlds(worlds)
 {
     ui->setupUi(this);
@@ -311,8 +313,15 @@ void WorldListPage::mceditState(LoggedProcess::State state)
 
 void WorldListPage::worldChanged(const QModelIndex &current, const QModelIndex &previous)
 {
+    auto mcInst = std::dynamic_pointer_cast<MinecraftInstance>(m_inst);
+    bool enableJoinActions = mcInst && mcInst->getPackProfile()->getComponent("net.minecraft")->getReleaseDateTime() >= g_VersionFilterData.quickPlayBeginsDate;
+
     QModelIndex index = getSelectedWorld();
     bool enable = index.isValid();
+    // FIXME: Hide the join buttons if the Minecraft version is too old instead of just disabling them.
+    // ui->actionJoin->setVisible(false) had no effect for some reason, at least on my machine -arthomnix
+    ui->actionJoin->setEnabled(enable && enableJoinActions);
+    ui->actionJoinOffline->setEnabled(enable && enableJoinActions);
     ui->actionCopy_Seed->setEnabled(enable);
     ui->actionMCEdit->setEnabled(enable);
     ui->actionRemove->setEnabled(enable);
@@ -407,6 +416,31 @@ void WorldListPage::on_actionRename_triggered()
 void WorldListPage::on_actionRefresh_triggered()
 {
     m_worlds->update();
+}
+
+void WorldListPage::joinSelectedWorld(bool online)
+{
+    auto index = getSelectedWorld();
+    if (!index.isValid())
+    {
+        return;
+    }
+
+    auto worldVariant = m_worlds->data(index, WorldList::ObjectRole);
+    auto world = (World *) worldVariant.value<void *>();
+    auto name = world->folderName();
+
+    APPLICATION->launch(m_inst, online, nullptr, std::make_shared<QuickPlayTarget>(QuickPlayTarget::parseSingleplayer(name)));
+}
+
+void WorldListPage::on_actionJoin_triggered()
+{
+    joinSelectedWorld(true);
+}
+
+void WorldListPage::on_actionJoinOffline_triggered()
+{
+    joinSelectedWorld(false);
 }
 
 #include "WorldListPage.moc"

--- a/launcher/ui/pages/instance/WorldListPage.cpp
+++ b/launcher/ui/pages/instance/WorldListPage.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 MultiMC Contributors
+/* Copyright 2015-2023 MultiMC Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/ui/pages/instance/WorldListPage.cpp
+++ b/launcher/ui/pages/instance/WorldListPage.cpp
@@ -318,8 +318,14 @@ void WorldListPage::worldChanged(const QModelIndex &current, const QModelIndex &
 
     QModelIndex index = getSelectedWorld();
     bool enable = index.isValid();
-    // FIXME: Hide the join buttons if the Minecraft version is too old instead of just disabling them.
-    // ui->actionJoin->setVisible(false) had no effect for some reason, at least on my machine -arthomnix
+    ui->actionJoin->setVisible(enableJoinActions);
+    ui->actionJoinOffline->setVisible(enableJoinActions);
+    // The above lines will only hide the actions from the right click menu, to hide them from the toolbar we need to do this.
+    // If any more actions are added above the Join/Join Offline actions, these indices will need to be updated!
+    ui->toolBar->actions().at(2)->setVisible(enableJoinActions);
+    ui->toolBar->actions().at(3)->setVisible(enableJoinActions);
+    // Also disable the separator so there aren't 2 separators in a row
+    ui->toolBar->actions().at(4)->setVisible(enableJoinActions);
     ui->actionJoin->setEnabled(enable && enableJoinActions);
     ui->actionJoinOffline->setEnabled(enable && enableJoinActions);
     ui->actionCopy_Seed->setEnabled(enable);

--- a/launcher/ui/pages/instance/WorldListPage.h
+++ b/launcher/ui/pages/instance/WorldListPage.h
@@ -34,7 +34,7 @@ class WorldListPage : public QMainWindow, public BasePage
 
 public:
     explicit WorldListPage(
-        BaseInstance *inst,
+        InstancePtr inst,
         std::shared_ptr<WorldList> worlds,
         QWidget *parent = 0
     );
@@ -67,13 +67,14 @@ protected:
     QMenu * createPopupMenu() override;
 
 protected:
-    BaseInstance *m_inst;
+    InstancePtr m_inst;
 
 private:
     QModelIndex getSelectedWorld();
     bool isWorldSafe(QModelIndex index);
     bool worldSafetyNagQuestion();
     void mceditError();
+    void joinSelectedWorld(bool online);
 
 private:
     Ui::WorldListPage *ui;
@@ -92,6 +93,8 @@ private slots:
     void on_actionView_Folder_triggered();
     void on_actionDatapacks_triggered();
     void on_actionReset_Icon_triggered();
+    void on_actionJoin_triggered();
+    void on_actionJoinOffline_triggered();
     void worldChanged(const QModelIndex &current, const QModelIndex &previous);
     void mceditState(LoggedProcess::State state);
 

--- a/launcher/ui/pages/instance/WorldListPage.h
+++ b/launcher/ui/pages/instance/WorldListPage.h
@@ -1,4 +1,4 @@
-/* Copyright 2015-2021 MultiMC Contributors
+/* Copyright 2015-2023 MultiMC Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/launcher/ui/pages/instance/WorldListPage.ui
+++ b/launcher/ui/pages/instance/WorldListPage.ui
@@ -81,6 +81,9 @@
    </attribute>
    <addaction name="actionAdd"/>
    <addaction name="separator"/>
+   <addaction name="actionJoin" />
+   <addaction name="actionJoinOffline" />
+   <addaction name="separator" />
    <addaction name="actionRename"/>
    <addaction name="actionCopy"/>
    <addaction name="actionRemove"/>
@@ -95,6 +98,22 @@
   <action name="actionAdd">
    <property name="text">
     <string>Add</string>
+   </property>
+  </action>
+  <action name="actionJoin">
+   <property name="text">
+    <string>Join</string>
+   </property>
+   <property name="toolTip">
+    <string>Launch the instance directly into the selected world</string>
+   </property>
+  </action>
+  <action name="actionJoinOffline">
+   <property name="text">
+    <string>Join offline</string>
+   </property>
+   <property name="toolTip">
+    <string>Launch the instance in offline mode directly into the selected world</string>
    </property>
   </action>
   <action name="actionRename">

--- a/launcher/ui/pages/instance/WorldListPage.ui
+++ b/launcher/ui/pages/instance/WorldListPage.ui
@@ -81,9 +81,8 @@
    </attribute>
    <addaction name="actionAdd"/>
    <addaction name="separator"/>
-   <addaction name="actionJoin" />
-   <addaction name="actionJoinOffline" />
-   <addaction name="separator" />
+   <addaction name="actionJoin"/>
+   <addaction name="actionJoinOffline"/>
    <addaction name="actionRename"/>
    <addaction name="actionCopy"/>
    <addaction name="actionRemove"/>

--- a/launcher/ui/widgets/WideBar.cpp
+++ b/launcher/ui/widgets/WideBar.cpp
@@ -20,7 +20,6 @@ private slots:
         setText(m_action->text());
         setIcon(m_action->icon());
         setToolTip(m_action->toolTip());
-        setHidden(!m_action->isVisible());
         setFocusPolicy(Qt::NoFocus);
     }
 private:
@@ -63,6 +62,9 @@ void WideBar::addAction(QAction* action)
 {
     auto entry = new BarEntry();
     entry->qAction = addWidget(new ActionButton(action, this));
+    connect(action, &QAction::changed, entry->qAction, [entry, action](){
+        entry->qAction->setVisible(action->isVisible());
+    });
     entry->wideAction = action;
     entry->type = BarEntry::Action;
     m_entries.push_back(entry);

--- a/libraries/launcher/org/multimc/onesix/OneSixLauncher.java
+++ b/libraries/launcher/org/multimc/onesix/OneSixLauncher.java
@@ -55,6 +55,8 @@ public class OneSixLauncher implements Launcher
     private String serverPort;
     private boolean useQuickPlay;
 
+    private String joinWorld;
+
     // the much abused system classloader, for convenience (for further abuse)
     private ClassLoader cl;
 
@@ -82,6 +84,7 @@ public class OneSixLauncher implements Launcher
         serverAddress = params.firstSafe("serverAddress", null);
         serverPort = params.firstSafe("serverPort", null);
         useQuickPlay = params.firstSafe("useQuickPlay").startsWith("1");
+        joinWorld = params.firstSafe("joinWorld", null);
 
         cwd = System.getProperty("user.dir");
 
@@ -183,6 +186,12 @@ public class OneSixLauncher implements Launcher
             mcparams.add(Integer.toString(winSizeW));
             mcparams.add("--height");
             mcparams.add(Integer.toString(winSizeH));
+        }
+
+        if (joinWorld != null)
+        {
+            mcparams.add("--quickPlaySingleplayer");
+            mcparams.add(joinWorld);
         }
 
         if (serverAddress != null)


### PR DESCRIPTION
Adds support for launching directly into a singleplayer world using 23w14a's new Quick Play feature.
This can be done in 3 ways:
* Via new "Join" and "Join Offline" buttons on the Edit Instance > Worlds screen (enabled only on 23w14a and higher instances)
* Via an instance setting, similar to the one for servers (again, only enabled on 23w14a and higher)
* Via a new `--world`/`-w` CLI option (this is mutually exclusive with `--server`; no validation is performed on the Minecraft version but the help text specifies that it only works on 23w14a and higher)

Stuff still to do:
- [x] Hide the Join and Join Offline buttons on Edit Instance > Worlds if the version is too old, instead of just disabling them
- [x] Add a "join world on launch" option to the shortcut creation dialog