### PR TITLE
NOISSUE Fix shortcut dialog bugs

### DIFF
--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -45,6 +45,8 @@ CreateShortcutDialog::CreateShortcutDialog(QWidget *parent, InstancePtr instance
 
     // TODO: check if version is affected by crashing when joining servers on launch, ideally in meta
 
+    bool instanceSupportsQuickPlay = false;
+
     auto mcInstance = std::dynamic_pointer_cast<MinecraftInstance>(instance);
     if (mcInstance)
     {
@@ -52,6 +54,7 @@ CreateShortcutDialog::CreateShortcutDialog(QWidget *parent, InstancePtr instance
 
         if (mcInstance->getPackProfile()->getComponent("net.minecraft")->getReleaseDateTime() >= g_VersionFilterData.quickPlayBeginsDate)
         {
+            instanceSupportsQuickPlay = true;
             mcInstance->worldList()->update();
             for (const auto &world : mcInstance->worldList()->allWorlds())
             {
@@ -59,7 +62,8 @@ CreateShortcutDialog::CreateShortcutDialog(QWidget *parent, InstancePtr instance
             }
         }
     }
-    else
+
+    if (!instanceSupportsQuickPlay)
     {
         ui->joinServerRadioButton->setChecked(true);
         ui->joinSingleplayerRadioButton->setVisible(false);

--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -111,9 +111,11 @@ void CreateShortcutDialog::updateDialogState()
 {
     ui->buttonBox->button(QDialogButtonBox::StandardButton::Ok)->setEnabled(
             !ui->shortcutPath->text().isEmpty()
-            && (!ui->joinWorldCheckBox->isChecked() || ui->joinServerRadioButton->isChecked() || ui->joinSingleplayerRadioButton->isChecked())
-            && (!ui->joinServerRadioButton->isChecked() || !ui->joinServer->text().isEmpty())
-            && (!ui->joinSingleplayerRadioButton->isChecked() || !ui->joinSingleplayer->currentText().isEmpty())
+            && (
+                    !ui->joinWorldCheckBox->isChecked()
+                    || (ui->joinServerRadioButton->isChecked() && !ui->joinServer->text().isEmpty())
+                    || (ui->joinSingleplayerRadioButton->isChecked() && !ui->joinSingleplayer->currentText().isEmpty())
+                )
             && (!ui->offlineUsernameCheckBox->isChecked() || !ui->offlineUsername->text().isEmpty())
             && (!ui->useProfileCheckBox->isChecked() || !ui->profileComboBox->currentText().isEmpty())
     );

--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -46,13 +46,17 @@ CreateShortcutDialog::CreateShortcutDialog(QWidget *parent, InstancePtr instance
     // TODO: check if version is affected by crashing when joining servers on launch, ideally in meta
 
     auto mcInstance = std::dynamic_pointer_cast<MinecraftInstance>(instance);
-    mcInstance->getPackProfile()->reload(Net::Mode::Online);
-    if (mcInstance && mcInstance->getPackProfile()->getComponent("net.minecraft")->getReleaseDateTime() >= g_VersionFilterData.quickPlayBeginsDate)
+    if (mcInstance)
     {
-        mcInstance->worldList()->update();
-        for (const auto &world : mcInstance->worldList()->allWorlds())
+        mcInstance->getPackProfile()->reload(Net::Mode::Online);
+
+        if (mcInstance->getPackProfile()->getComponent("net.minecraft")->getReleaseDateTime() >= g_VersionFilterData.quickPlayBeginsDate)
         {
-            ui->joinSingleplayer->addItem(world.folderName());
+            mcInstance->worldList()->update();
+            for (const auto &world : mcInstance->worldList()->allWorlds())
+            {
+                ui->joinSingleplayer->addItem(world.folderName());
+            }
         }
     }
     else

--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -46,7 +46,7 @@ CreateShortcutDialog::CreateShortcutDialog(QWidget *parent, InstancePtr instance
     // TODO: check if version is affected by crashing when joining servers on launch, ideally in meta
 
     auto mcInstance = std::dynamic_pointer_cast<MinecraftInstance>(instance);
-    mcInstance->getPackProfile()->reload(Net::Mode::Offline);
+    mcInstance->getPackProfile()->reload(Net::Mode::Online);
     if (mcInstance && mcInstance->getPackProfile()->getComponent("net.minecraft")->getReleaseDateTime() >= g_VersionFilterData.quickPlayBeginsDate)
     {
         mcInstance->worldList()->update();

--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -72,6 +72,8 @@ CreateShortcutDialog::CreateShortcutDialog(QWidget *parent, InstancePtr instance
     ui->createScriptCheckBox->setChecked(true);
 #endif
 
+    connect(ui->joinWorldCheckBox, &QCheckBox::toggled, this, &CreateShortcutDialog::updateDialogState);
+
     updateDialogState();
 }
 

--- a/launcher/ui/dialogs/CreateShortcutDialog.ui
+++ b/launcher/ui/dialogs/CreateShortcutDialog.ui
@@ -1,9 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
- Copyright 2022-2023 arthomnix
- This source is subject to the Microsoft Public License (MS-PL).
- Please see the COPYING.md file for more information.
--->
 <ui version="4.0">
  <class>CreateShortcutDialog</class>
  <widget class="QDialog" name="CreateShortcutDialog">
@@ -447,6 +442,22 @@
     <hint type="sourcelabel">
      <x>140</x>
      <y>132</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>397</x>
+     <y>164</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>joinWorldCheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>CreateShortcutDialog</receiver>
+   <slot>updateDialogState()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>140</x>
+     <y>59</y>
     </hint>
     <hint type="destinationlabel">
      <x>397</x>

--- a/launcher/ui/dialogs/CreateShortcutDialog.ui
+++ b/launcher/ui/dialogs/CreateShortcutDialog.ui
@@ -454,22 +454,6 @@
     </hint>
    </hints>
   </connection>
-  <connection>
-   <sender>joinWorldCheckBox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>CreateShortcutDialog</receiver>
-   <slot>updateDialogState()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>140</x>
-     <y>59</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>397</x>
-     <y>164</y>
-    </hint>
-   </hints>
-  </connection>
  </connections>
  <slots>
   <slot>updateDialogState()</slot>

--- a/launcher/ui/dialogs/CreateShortcutDialog.ui
+++ b/launcher/ui/dialogs/CreateShortcutDialog.ui
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright 2022-2023 arthomnix
+ This source is subject to the Microsoft Public License (MS-PL).
+ Please see the COPYING.md file for more information.
+-->
 <ui version="4.0">
  <class>CreateShortcutDialog</class>
  <widget class="QDialog" name="CreateShortcutDialog">


### PR DESCRIPTION
Fixes bugs in the create shortcut dialog where the OK button and server address text box were always disabled on instances that don't support Quick Play.