### PR TITLE
NOISSUE Fix server address text box in instance settings being always disabled on non-Quick Play instances

### DIFF
--- a/launcher/ui/pages/instance/InstanceSettingsPage.cpp
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.cpp
@@ -46,6 +46,7 @@ InstanceSettingsPage::InstanceSettingsPage(BaseInstance *inst, QWidget *parent)
         ui->worldRadioButton->setVisible(false);
         ui->worldsComboBox->setVisible(false);
         ui->serverAddressRadioButton->setChecked(true);
+        connect(ui->quickPlayGroupBox, &QGroupBox::toggled, ui->serverJoinAddress, &QLineEdit::setEnabled);
     }
 
     loadSettings();


### PR DESCRIPTION
Similar bug to #5162