### PR TITLE
NOISSUE Update Debian/Ubuntu package

### DIFF
--- a/launcher/package/ubuntu/multimc/DEBIAN/control
+++ b/launcher/package/ubuntu/multimc/DEBIAN/control
@@ -1,12 +1,12 @@
 Package: multimc
-Version: 1.6-2
+Version: 1.7-1
 Architecture: all
 Maintainer: Petr Mrázek <peterix@gmail.com>
 Section: games
 Priority: optional
 Installed-Size: 75
 Depends: zenity, desktop-file-utils, libqt5widgets5, libqt5gui5, libqt5network5, libqt5core5a, libqt5xml5, libqt5concurrent5, wget
-Recommends: openjdk-8-jre
+Recommends: openjdk-8-jre, openjdk-17-jre
 Homepage: http://multimc.org
 Description: A local install wrapper for MultiMC
 

--- a/launcher/package/ubuntu/multimc/opt/multimc/run.sh
+++ b/launcher/package/ubuntu/multimc/opt/multimc/run.sh
@@ -4,9 +4,9 @@ INSTDIR="${XDG_DATA_HOME-$HOME/.local/share}/multimc"
 
 if [ `getconf LONG_BIT` = "64" ]
 then
-    PACKAGE="mmc-stable-lin64.tar.gz"
+    PACKAGE="mmc-develop-lin64.tar.gz"
 else
-    PACKAGE="mmc-stable-lin32.tar.gz"
+    PACKAGE="mmc-develop-lin32.tar.gz"
 fi
 
 deploy() {


### PR DESCRIPTION
Makes the Debian package download the develop version of MultiMC since stable is no longer updated. Also makes the package recommend Java 17 as well as 8 since newer game versions require it.

The Arch pkgbuild repo should also be updated when this is merged.