### PR TITLE
Fixed Wrong Proxy Settings Message

### DIFF
--- a/launcher/ui/pages/global/ProxyPage.ui
+++ b/launcher/ui/pages/global/ProxyPage.ui
@@ -39,7 +39,7 @@
        <item>
         <widget class="QLabel" name="proxyPlainTextWarningLabel_2">
          <property name="text">
-          <string>This only applies to the launcher. Minecraft does not accept proxy settings.</string>
+          <string>This only applies to the launcher.</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>


### PR DESCRIPTION
![image](https://github.com/MultiMC/Launcher/assets/77546847/b986d796-9d57-40f7-bdbf-87163a18694a)
It says "Minecraft does not accept proxy settings.", but thats wrong:
![image](https://github.com/MultiMC/Launcher/assets/77546847/1bb87d75-4555-43d6-88a2-5cc059dc48a7)
(Decompiled 1.20.1 using jd-gui)