### PR TITLE
GH-5166 Adding user account state to be refreshed during Instance Launch

### DIFF
--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -117,6 +117,11 @@ void LaunchController::login() {
 
     while (tryagain)
     {
+        // Force account refresh on the account used to launch the instance,
+        // updating the AccountState everytime between instance launch
+        auto accounts = APPLICATION->accounts();
+        accounts->requestRefresh(m_accountToUse->internalId());
+
         m_session = std::make_shared<AuthSession>();
         m_session->wants_online = m_online;
         m_accountToUse->fillSession(m_session);


### PR DESCRIPTION
In the login function of LaunchController, added requestRefresh on the current m_accountToUse. This allows the accountState of accountToUse to be updated before running through what login is meant to depending on the accountState. This is to allow for the cases where a device might be back online after launching the Launcher. Putting this in the tryagain while loop also allows to check if a users account is expired during the login process.

Adds a force account refresh during the login process, updating the account state before the program performs an action depending on the account state. 
This allows for users to start an instance with no internet connection, realise and update their internet connection and start an instance again with no issue.
Putting this in the tryagain while loop also allows to check if a users account is expired during the login process.
This also resolves issue GH-4356.
Tested as much as I could on Ubuntu Linux 22.04.3 LTS. No noticeable lag or crashes noticed with multiple launches rapidly in a row and was able to confirm that the account status does change in this case.