### PR TITLE
fix not seeing java as 64 bit on M1 processors

### DIFF
--- a/launcher/java/JavaChecker.cpp
+++ b/launcher/java/JavaChecker.cpp
@@ -129,7 +129,7 @@ void JavaChecker::finished(int exitcode, QProcess::ExitStatus status)
     auto os_arch = results["os.arch"];
     auto java_version = results["java.version"];
     auto java_vendor = results["java.vendor"];
-    bool is_64 = os_arch == "x86_64" || os_arch == "amd64";
+    bool is_64 = os_arch == "x86_64" || os_arch == "amd64" || os_arch == "aarch64";
 
 
     result.validity = JavaCheckResult::Validity::Valid;


### PR DESCRIPTION
On macOS with an M1 or M2 processor, it returns `os.arch=aarch64` which is not recognized as a 64 bit architecture by the code.

This fixes that and the spurious warning goes away:

```
Checking Java version...
Java is version 21.0.1, using 32-bit architecture, from Eclipse Adoptium.


Your Java architecture is not matching your system architecture. You might want to install a 64bit Java version.
```