### PR TITLE
Simplify Microsoft Login

### DIFF
--- a/launcher/ui/dialogs/MSALoginDialog.cpp
+++ b/launcher/ui/dialogs/MSALoginDialog.cpp
@@ -90,7 +90,7 @@ void MSALoginDialog::showVerificationUriAndCode(const QUrl& uri, const QString& 
 
     QString urlString = url.toString();
     QString linkString = QString("<a href=\"%1\">%2</a>").arg(urlString, urlString);
-    ui->label->setText(tr("<p>Please open up %1 in a browser to proceed with login.</p>").arg(linkString));
+    ui->label->setText(tr("<p>Please open up %1 in a browser to proceed with login. (Code: <b>%2</b>)</p>").arg(linkString, code));
 
     m_code = code;
 }

--- a/launcher/ui/dialogs/MSALoginDialog.cpp
+++ b/launcher/ui/dialogs/MSALoginDialog.cpp
@@ -1,4 +1,4 @@
-/* Copyright 2013-2022 MultiMC Contributors
+/* Copyright 2013-2023 MultiMC Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 
 #include <QtWidgets/QPushButton>
 #include <QUrl>
+#include <QUrlQuery>
 #include <QClipboard>
 
 MSALoginDialog::MSALoginDialog(QWidget *parent) : QDialog(parent), ui(new Ui::MSALoginDialog)
@@ -82,9 +83,13 @@ void MSALoginDialog::showVerificationUriAndCode(const QUrl& uri, const QString& 
     ui->progressBar->setMaximum(expiresIn);
     ui->progressBar->setValue(m_externalLoginElapsed);
 
-    QString urlString = uri.toString();
+    QUrl url = QUrl(uri);
+    QUrlQuery otcQuery = QUrlQuery(url);
+    otcQuery.addQueryItem(QString("otc"), code);
+
+    QString urlString = url.toString();
     QString linkString = QString("<a href=\"%1\">%2</a>").arg(urlString, urlString);
-    ui->label->setText(tr("<p>Please open up %1 in a browser and put in the code <b>%2</b> to proceed with login.</p>").arg(linkString, code));
+    ui->label->setText(tr("<p>Please open up %1 in a browser to proceed with login.</p>").arg(linkString));
 
     m_code = code;
 }

--- a/launcher/ui/dialogs/MSALoginDialog.cpp
+++ b/launcher/ui/dialogs/MSALoginDialog.cpp
@@ -86,6 +86,7 @@ void MSALoginDialog::showVerificationUriAndCode(const QUrl& uri, const QString& 
     QUrl url = QUrl(uri);
     QUrlQuery otcQuery = QUrlQuery(url);
     otcQuery.addQueryItem(QString("otc"), code);
+    url.setQuery(otcQuery);
 
     QString urlString = url.toString();
     QString linkString = QString("<a href=\"%1\">%2</a>").arg(urlString, urlString);

--- a/launcher/ui/dialogs/MSALoginDialog.cpp
+++ b/launcher/ui/dialogs/MSALoginDialog.cpp
@@ -83,15 +83,16 @@ void MSALoginDialog::showVerificationUriAndCode(const QUrl& uri, const QString& 
     ui->progressBar->setMaximum(expiresIn);
     ui->progressBar->setValue(m_externalLoginElapsed);
 
-    QUrl url = QUrl(uri);
-    QUrlQuery otcQuery = QUrlQuery(url);
+    QUrl codeUrl = QUrl(uri);
+    QUrlQuery otcQuery = QUrlQuery(codeUrl);
     otcQuery.addQueryItem(QString("otc"), code);
-    url.setQuery(otcQuery);
+    codeUrl.setQuery(otcQuery);
 
-    QString urlString = url.toString();
-    QString linkString = QString("<a href=\"%1\">%2</a>").arg(urlString, urlString);
-    ui->label->setText(tr("<p>Please open up %1 in a browser to proceed with login. (Code: <b>%2</b>)</p>").arg(linkString, code));
+    QString urlString = uri.toString();
+    QString codeUrlString = codeUrl.toString();
 
+    QString linkString = QString("<a href=\"%1\">%2 in a browser and put in the code <b>%3</b></a>").arg(codeUrlString, urlString, code);
+    ui->label->setText(tr("<p>Please open up %1 to proceed with login.</p>").arg(linkString));
     m_code = code;
 }
 


### PR DESCRIPTION
removes the need to enter the code when opening the login link by adding it as the `otc` query parameter to the url