### PR TITLE
GH-5232 Add Install NeoForge button

### DIFF
--- a/launcher/minecraft/VersionFilterData.cpp
+++ b/launcher/minecraft/VersionFilterData.cpp
@@ -70,4 +70,7 @@ VersionFilterData::VersionFilterData()
     java16BeginsDate    = timeFromS3Time("2021-05-12T11:19:15+00:00");
     java17BeginsDate    = timeFromS3Time("2021-11-16T17:04:48+00:00");
     quickPlayBeginsDate = timeFromS3Time("2023-04-05T12:05:17+00:00");
+    liteLoaderEndsDate  = timeFromS3Time("2017-09-18T08:39:46+00:00");
+    fabricBeginsDate    = timeFromS3Time("2019-04-23T14:52:44+00:00");
+    neoForgeBeginsDate  = timeFromS3Time("2023-09-20T09:02:57+00:00");
 }

--- a/launcher/minecraft/VersionFilterData.cpp
+++ b/launcher/minecraft/VersionFilterData.cpp
@@ -72,5 +72,5 @@ VersionFilterData::VersionFilterData()
     quickPlayBeginsDate = timeFromS3Time("2023-04-05T12:05:17+00:00");
     liteLoaderEndsDate  = timeFromS3Time("2017-09-18T08:39:46+00:00");
     fabricBeginsDate    = timeFromS3Time("2019-04-23T14:52:44+00:00");
-    neoForgeBeginsDate  = timeFromS3Time("2023-09-20T09:02:57+00:00");
+    neoForgeBeginsDate  = timeFromS3Time("2023-06-12T13:25:51+00:00");
 }

--- a/launcher/minecraft/VersionFilterData.h
+++ b/launcher/minecraft/VersionFilterData.h
@@ -29,5 +29,11 @@ struct VersionFilterData
     QDateTime java17BeginsDate;
     // release date of first version to use --quickPlayMultiplayer instead of --server/--port for directly joining servers
     QDateTime quickPlayBeginsDate;
+    // release date of last version to support LiteLoader (1.12.2)
+    QDateTime liteLoaderEndsDate;
+    // release date of first version supported by Fabric/Quilt (1.14)
+    QDateTime fabricBeginsDate;
+    // release date of first version supported by NeoForge (1.20.2)
+    QDateTime neoForgeBeginsDate;
 };
 extern VersionFilterData g_VersionFilterData;

--- a/launcher/minecraft/VersionFilterData.h
+++ b/launcher/minecraft/VersionFilterData.h
@@ -33,7 +33,7 @@ struct VersionFilterData
     QDateTime liteLoaderEndsDate;
     // release date of first version supported by Fabric/Quilt (1.14)
     QDateTime fabricBeginsDate;
-    // release date of first version supported by NeoForge (1.20.2)
+    // release date of first version supported by NeoForge (1.20.1)
     QDateTime neoForgeBeginsDate;
 };
 extern VersionFilterData g_VersionFilterData;

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -444,6 +444,35 @@ void VersionPage::on_actionInstall_Forge_triggered()
     }
 }
 
+void VersionPage::on_actionInstall_NeoForge_triggered()
+{
+    auto vlist = APPLICATION->metadataIndex()->get("net.neoforged");
+    if(!vlist)
+    {
+        return;
+    }
+    VersionSelectDialog vselect(vlist.get(), tr("Select NeoForge version"), this);
+    vselect.setExactFilter(BaseVersionList::ParentVersionRole, m_profile->getComponentVersion("net.minecraft"));
+    vselect.setEmptyString(tr("No NeoForge versions are currently available for Minecraft ") + m_profile->getComponentVersion("net.minecraft"));
+    vselect.setEmptyErrorString(tr("Couldn't load or download the NeoForge version lists!"));
+
+    auto currentVersion = m_profile->getComponentVersion("net.neoforged");
+    if(!currentVersion.isEmpty())
+    {
+        vselect.setCurrentVersion(currentVersion);
+    }
+
+    if (vselect.exec() && vselect.selectedVersion())
+    {
+        auto vsn = vselect.selectedVersion();
+        m_profile->setComponentVersion("net.neoforged", vsn->descriptor());
+        m_profile->resolve(Net::Mode::Online);
+        // m_profile->installVersion();
+        preselect(m_profile->rowCount(QModelIndex())-1);
+        m_container->refreshContainer();
+    }
+}
+
 void VersionPage::on_actionInstall_Fabric_triggered()
 {
     auto vlist = APPLICATION->metadataIndex()->get("net.fabricmc.fabric-loader");

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -39,6 +39,7 @@
 #include "minecraft/PackProfile.h"
 #include "minecraft/auth/AccountList.h"
 #include "minecraft/mod/Mod.h"
+#include "minecraft/VersionFilterData.h"
 #include "icons/IconList.h"
 #include "Exception.h"
 #include "Version.h"
@@ -209,15 +210,18 @@ void VersionPage::updateRunningStatus(bool running)
 
 void VersionPage::updateVersionControls()
 {
-    // FIXME: this is a dirty hack
-    auto minecraftVersion = Version(m_profile->getComponentVersion("net.minecraft"));
+    // FIXME: This is better than the broken stuff we had before, but it would probably be better to handle this in meta somehow
+    auto minecraftReleaseDate = m_profile->getComponent("net.minecraft")->getReleaseDateTime();
 
-    bool supportsFabric = minecraftVersion >= Version("1.14");
+    bool supportsFabric = minecraftReleaseDate >= g_VersionFilterData.fabricBeginsDate;
     ui->actionInstall_Fabric->setEnabled(controlsEnabled && supportsFabric);
     ui->actionInstall_Quilt->setEnabled((controlsEnabled) && supportsFabric);
 
-    bool supportsLiteLoader = minecraftVersion <= Version("1.12.2");
+    bool supportsLiteLoader = minecraftReleaseDate <= g_VersionFilterData.liteLoaderEndsDate;
     ui->actionInstall_LiteLoader->setEnabled(controlsEnabled && supportsLiteLoader);
+
+    bool supportsNeoForge = minecraftReleaseDate >= g_VersionFilterData.neoForgeBeginsDate;
+    ui->actionInstall_NeoForge->setEnabled(controlsEnabled && supportsNeoForge);
 
     updateButtons();
 }

--- a/launcher/ui/pages/instance/VersionPage.h
+++ b/launcher/ui/pages/instance/VersionPage.h
@@ -51,6 +51,7 @@ public:
 private slots:
     void on_actionChange_version_triggered();
     void on_actionInstall_Forge_triggered();
+    void on_actionInstall_NeoForge_triggered();
     void on_actionInstall_Fabric_triggered();
     void on_actionInstall_Quilt_triggered();
     void on_actionAdd_Empty_triggered();

--- a/launcher/ui/pages/instance/VersionPage.ui
+++ b/launcher/ui/pages/instance/VersionPage.ui
@@ -106,6 +106,7 @@
    <addaction name="actionRevert"/>
    <addaction name="separator"/>
    <addaction name="actionInstall_Forge"/>
+   <addaction name="actionInstall_NeoForge"/>
    <addaction name="actionInstall_Fabric"/>
    <addaction name="actionInstall_Quilt"/>
    <addaction name="actionInstall_LiteLoader"/>
@@ -268,6 +269,14 @@
    </property>
    <property name="toolTip">
     <string>Open the instance's local libraries folder.</string>
+   </property>
+  </action>
+  <action name="actionInstall_NeoForge">
+   <property name="text">
+    <string>Install NeoForge</string>
+   </property>
+   <property name="toolTip">
+    <string>Install the NeoForge package.</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Add a button to install NeoForge.
Depends on https://github.com/MultiMC/ForgeWrapper/pull/1 and https://github.com/MultiMC/meta/pull/18. Closes #5232.

(Untested obviously since there is no NeoForge metadata yet.)

I would also like to fix the very broken code to detect whether Fabric/Quilt are supported (which currently doesn't disable the Install Fabric/Quilt buttons on pre-1.0 versions), and add NeoForge support detection, before merging.