### PR TITLE
HOTFIX: Generate Java Version 21 Error in logs

### DIFF
--- a/launcher/minecraft/VersionFilterData.cpp
+++ b/launcher/minecraft/VersionFilterData.cpp
@@ -69,6 +69,7 @@ VersionFilterData::VersionFilterData()
     java8BeginsDate     = timeFromS3Time("2017-03-30T09:32:19+00:00");
     java16BeginsDate    = timeFromS3Time("2021-05-12T11:19:15+00:00");
     java17BeginsDate    = timeFromS3Time("2021-11-16T17:04:48+00:00");
+    java21BeginsDate    = timeFromS3Time("2024-04-03T11:49:39+00:00");
     quickPlayBeginsDate = timeFromS3Time("2023-04-05T12:05:17+00:00");
     liteLoaderEndsDate  = timeFromS3Time("2017-09-18T08:39:46+00:00");
     fabricBeginsDate    = timeFromS3Time("2019-04-23T14:52:44+00:00");

--- a/launcher/minecraft/VersionFilterData.h
+++ b/launcher/minecraft/VersionFilterData.h
@@ -27,6 +27,8 @@ struct VersionFilterData
     QDateTime java16BeginsDate;
     // release data of first version to require Java 17 (1.18 Pre Release 2)
     QDateTime java17BeginsDate;
+    // Release data of the first version to require java 21 (24w14a)
+    QDateTime java21BeginsDate;
     // release date of first version to use --quickPlayMultiplayer instead of --server/--port for directly joining servers
     QDateTime quickPlayBeginsDate;
     // release date of last version to support LiteLoader (1.12.2)

--- a/launcher/minecraft/launch/VerifyJavaInstall.cpp
+++ b/launcher/minecraft/launch/VerifyJavaInstall.cpp
@@ -34,6 +34,15 @@ void VerifyJavaInstall::executeTask() {
     auto javaVersion = m_inst->getJavaVersion();
     auto minecraftComponent = m_inst->getPackProfile()->getComponent("net.minecraft");
 
+    // Java 21 Requirement
+    if (minecraftComponent->getReleaseDateTime() >= g_VersionFilterData.java21BeginsDate) {
+        if (javaVersion.major() < 21) {
+            emit logLine("Minecraft 24w14a and above require the use of Java 21",
+                         MessageLevel::Fatal);
+            emitFailed(tr("Minecraft 24w14a and above require the use of Java 21"));
+            return;
+        }
+    }
     // Java 17 requirement
     if (minecraftComponent->getReleaseDateTime() >= g_VersionFilterData.java17BeginsDate) {
         if (javaVersion.major() < 17) {


### PR DESCRIPTION
This updates MultiMC to detect versions requiring Java 21.

Detects 24w14a and beyond