### PR TITLE
NOISSUE Centralize Mojang URLs

### DIFF
--- a/buildconfig/BuildConfig.h
+++ b/buildconfig/BuildConfig.h
@@ -91,10 +91,10 @@ public:
 
     QString RESOURCE_BASE = "https://resources.download.minecraft.net/";
     QString LIBRARY_BASE = "https://libraries.minecraft.net/";
-    QString API_BASE = "https://api.minecraftservices.com/";
-    QString AUTH_BASE = "https://authserver.mojang.com/";
-    QString SESSION_BASE = "https://sessionserver.mojang.com/";
-    QString TEXTURE_BASE = "http://textures.minecraft.net/";
+    QString API_BASE = "https://api.minecraftservices.com";
+    QString AUTH_BASE = "https://authserver.mojang.com";
+    QString SESSION_BASE = "https://sessionserver.mojang.com";
+    QString TEXTURE_BASE = "http://textures.minecraft.net";
     QString IMGUR_BASE_URL = "https://api.imgur.com/3/";
     QString FMLLIBS_BASE_URL = "https://files.multimc.org/fmllibs/";
     QString TRANSLATIONS_BASE_URL = "https://files.multimc.org/translations/";

--- a/buildconfig/BuildConfig.h
+++ b/buildconfig/BuildConfig.h
@@ -91,7 +91,10 @@ public:
 
     QString RESOURCE_BASE = "https://resources.download.minecraft.net/";
     QString LIBRARY_BASE = "https://libraries.minecraft.net/";
+    QString API_BASE = "https://api.minecraftservices.com/";
     QString AUTH_BASE = "https://authserver.mojang.com/";
+    QString SESSION_BASE = "https://sessionserver.mojang.com/";
+    QString TEXTURE_BASE = "http://textures.minecraft.net/";
     QString IMGUR_BASE_URL = "https://api.imgur.com/3/";
     QString FMLLIBS_BASE_URL = "https://files.multimc.org/fmllibs/";
     QString TRANSLATIONS_BASE_URL = "https://files.multimc.org/translations/";

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -1,6 +1,7 @@
 #include "LaunchController.h"
 #include "minecraft/auth/AccountList.h"
 #include "Application.h"
+#include "BuildConfig.h"
 
 #include "ui/MainWindow.h"
 #include "ui/InstanceWindow.h"
@@ -345,7 +346,7 @@ void LaunchController::launchInstance()
         online_mode = "online";
 
         // Prepend Server Status
-        QStringList servers = {"authserver.mojang.com", "session.minecraft.net", "textures.minecraft.net", "api.mojang.com"};
+        QStringList servers = {QUrl(BuildConfig.AUTH_BASE).host(), QUrl(BuildConfig.SESSION_BASE).host(), QUrl(BuildConfig.TEXTURE_BASE).host(), QUrl(BuildConfig.API_BASE).host()};
         QString resolved_servers = "";
         QHostInfo host_info;
 

--- a/launcher/minecraft/auth/Parsers.cpp
+++ b/launcher/minecraft/auth/Parsers.cpp
@@ -4,6 +4,8 @@
 #include <QJsonArray>
 #include <QDebug>
 
+#include "BuildConfig.h"
+
 namespace Parsers {
 
 bool getDateTime(QJsonValue value, QDateTime & out) {
@@ -256,7 +258,7 @@ bool parseForcedMigrationResponse(QByteArray & data, bool& result) {
     QJsonParseError jsonError;
     QJsonDocument doc = QJsonDocument::fromJson(data, &jsonError);
     if(jsonError.error) {
-        qWarning() << "Failed to parse response from https://api.minecraftservices.com/rollout/v1/msamigrationforced as JSON: " << jsonError.errorString();
+        qWarning() << "Failed to parse response from " << BuildConfig.API_BASE << "/rollout/v1/msamigrationforced as JSON: " << jsonError.errorString();
         return false;
     }
 
@@ -286,7 +288,7 @@ bool parseRolloutResponse(QByteArray & data, bool& result) {
     QJsonParseError jsonError;
     QJsonDocument doc = QJsonDocument::fromJson(data, &jsonError);
     if(jsonError.error) {
-        qWarning() << "Failed to parse response from https://api.minecraftservices.com/rollout/v1/msamigration as JSON: " << jsonError.errorString();
+        qWarning() << "Failed to parse response from " << BuildConfig.API_BASE << "/rollout/v1/msamigration as JSON: " << jsonError.errorString();
         return false;
     }
 
@@ -315,7 +317,7 @@ bool parseMojangResponse(QByteArray & data, Katabasis::Token &output) {
 #endif
     QJsonDocument doc = QJsonDocument::fromJson(data, &jsonError);
     if(jsonError.error) {
-        qWarning() << "Failed to parse response from api.minecraftservices.com/launcher/login as JSON: " << jsonError.errorString();
+        qWarning() << "Failed to parse response from " << BuildConfig.API_BASE << "/launcher/login as JSON: " << jsonError.errorString();
         return false;
     }
 

--- a/launcher/minecraft/auth/Yggdrasil.cpp
+++ b/launcher/minecraft/auth/Yggdrasil.cpp
@@ -26,6 +26,7 @@
 #include <QDebug>
 
 #include "Application.h"
+#include "BuildConfig.h"
 
 Yggdrasil::Yggdrasil(AccountData *data, QObject *parent)
     : AccountTask(data, parent)
@@ -84,7 +85,7 @@ void Yggdrasil::refresh() {
     req.insert("requestUser", false);
     QJsonDocument doc(req);
 
-    QUrl reqUrl("https://authserver.mojang.com/refresh");
+    QUrl reqUrl(QString("%1/refresh").arg(BuildConfig.AUTH_BASE));
     QByteArray requestData = doc.toJson();
 
     sendRequest(reqUrl, requestData);
@@ -129,7 +130,7 @@ void Yggdrasil::login(QString password) {
 
     QJsonDocument doc(req);
 
-    QUrl reqUrl("https://authserver.mojang.com/authenticate");
+    QUrl reqUrl(QString("%1/authenticate").arg(BuildConfig.AUTH_BASE));
     QNetworkRequest netRequest(reqUrl);
     QByteArray requestData = doc.toJson();
 

--- a/launcher/minecraft/auth/steps/EntitlementsStep.cpp
+++ b/launcher/minecraft/auth/steps/EntitlementsStep.cpp
@@ -6,6 +6,8 @@
 #include "minecraft/auth/AuthRequest.h"
 #include "minecraft/auth/Parsers.h"
 
+#include "BuildConfig.h"
+
 EntitlementsStep::EntitlementsStep(AccountData* data) : AuthStep(data) {}
 
 EntitlementsStep::~EntitlementsStep() noexcept = default;
@@ -18,7 +20,7 @@ QString EntitlementsStep::describe() {
 void EntitlementsStep::perform() {
     auto uuid = QUuid::createUuid();
     m_entitlementsRequestId = uuid.toString().remove('{').remove('}');
-    auto url = "https://api.minecraftservices.com/entitlements/license?requestId=" + m_entitlementsRequestId;
+    auto url = QString("%1/entitlements/license?requestId=%2").arg(BuildConfig.API_BASE).arg(m_entitlementsRequestId);
     QNetworkRequest request = QNetworkRequest(url);
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     request.setRawHeader("Accept", "application/json");

--- a/launcher/minecraft/auth/steps/ForcedMigrationStep.cpp
+++ b/launcher/minecraft/auth/steps/ForcedMigrationStep.cpp
@@ -5,6 +5,8 @@
 #include "minecraft/auth/AuthRequest.h"
 #include "minecraft/auth/Parsers.h"
 
+#include "BuildConfig.h"
+
 ForcedMigrationStep::ForcedMigrationStep(AccountData* data) : AuthStep(data) {
 
 }
@@ -16,7 +18,7 @@ QString ForcedMigrationStep::describe() {
 }
 
 void ForcedMigrationStep::perform() {
-    auto url = QUrl("https://api.minecraftservices.com/rollout/v1/msamigrationforced");
+    auto url = QString("%1/rollout/v1/msamigrationforced").arg(BuildConfig.API_BASE);
     QNetworkRequest request = QNetworkRequest(url);
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     request.setRawHeader("Authorization", QString("Bearer %1").arg(m_data->yggdrasilToken.token).toUtf8());

--- a/launcher/minecraft/auth/steps/LauncherLoginStep.cpp
+++ b/launcher/minecraft/auth/steps/LauncherLoginStep.cpp
@@ -6,6 +6,8 @@
 #include "minecraft/auth/Parsers.h"
 #include "minecraft/auth/AccountTask.h"
 
+#include "BuildConfig.h"
+
 LauncherLoginStep::LauncherLoginStep(AccountData* data) : AuthStep(data) {
 
 }
@@ -17,7 +19,7 @@ QString LauncherLoginStep::describe() {
 }
 
 void LauncherLoginStep::perform() {
-    auto requestURL = "https://api.minecraftservices.com/launcher/login";
+    auto requestURL = QString("%1/launcher/login").arg(BuildConfig.API_BASE);
     auto uhs = m_data->mojangservicesToken.extra["uhs"].toString();
     auto xToken = m_data->mojangservicesToken.token;
 

--- a/launcher/minecraft/auth/steps/MigrationEligibilityStep.cpp
+++ b/launcher/minecraft/auth/steps/MigrationEligibilityStep.cpp
@@ -5,6 +5,8 @@
 #include "minecraft/auth/AuthRequest.h"
 #include "minecraft/auth/Parsers.h"
 
+#include "BuildConfig.h"
+
 MigrationEligibilityStep::MigrationEligibilityStep(AccountData* data) : AuthStep(data) {
 
 }
@@ -16,7 +18,7 @@ QString MigrationEligibilityStep::describe() {
 }
 
 void MigrationEligibilityStep::perform() {
-    auto url = QUrl("https://api.minecraftservices.com/rollout/v1/msamigration");
+    auto url = QString("%1/rollout/v1/msamigration").arg(BuildConfig.API_BASE);
     QNetworkRequest request = QNetworkRequest(url);
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     request.setRawHeader("Authorization", QString("Bearer %1").arg(m_data->yggdrasilToken.token).toUtf8());

--- a/launcher/minecraft/auth/steps/MinecraftProfileStep.cpp
+++ b/launcher/minecraft/auth/steps/MinecraftProfileStep.cpp
@@ -5,6 +5,8 @@
 #include "minecraft/auth/AuthRequest.h"
 #include "minecraft/auth/Parsers.h"
 
+#include "BuildConfig.h"
+
 MinecraftProfileStep::MinecraftProfileStep(AccountData* data) : AuthStep(data) {
 
 }
@@ -17,7 +19,7 @@ QString MinecraftProfileStep::describe() {
 
 
 void MinecraftProfileStep::perform() {
-    auto url = QUrl("https://api.minecraftservices.com/minecraft/profile");
+    auto url = QString("%1/minecraft/profile").arg(BuildConfig.API_BASE);
     QNetworkRequest request = QNetworkRequest(url);
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     request.setRawHeader("Authorization", QString("Bearer %1").arg(m_data->yggdrasilToken.token).toUtf8());

--- a/launcher/minecraft/services/CapeChange.cpp
+++ b/launcher/minecraft/services/CapeChange.cpp
@@ -4,6 +4,7 @@
 #include <QHttpMultiPart>
 
 #include "Application.h"
+#include "BuildConfig.h"
 
 CapeChange::CapeChange(QObject *parent, QString token, QString cape)
     : Task(parent), m_capeId(cape), m_token(token)
@@ -11,7 +12,7 @@ CapeChange::CapeChange(QObject *parent, QString token, QString cape)
 }
 
 void CapeChange::setCape(QString& cape) {
-    QNetworkRequest request(QUrl("https://api.minecraftservices.com/minecraft/profile/capes/active"));
+    QNetworkRequest request(QString("%1/minecraft/profile/capes/active").arg(BuildConfig.API_BASE));
     auto requestString = QString("{\"capeId\":\"%1\"}").arg(m_capeId);
     request.setRawHeader("Authorization", QString("Bearer %1").arg(m_token).toLocal8Bit());
     QNetworkReply *rep = APPLICATION->network()->put(request, requestString.toUtf8());
@@ -25,7 +26,7 @@ void CapeChange::setCape(QString& cape) {
 }
 
 void CapeChange::clearCape() {
-    QNetworkRequest request(QUrl("https://api.minecraftservices.com/minecraft/profile/capes/active"));
+    QNetworkRequest request(QString("%1/minecraft/profile/capes/active").arg(BuildConfig.API_BASE));
     auto requestString = QString("{\"capeId\":\"%1\"}").arg(m_capeId);
     request.setRawHeader("Authorization", QString("Bearer %1").arg(m_token).toLocal8Bit());
     QNetworkReply *rep = APPLICATION->network()->deleteResource(request);

--- a/launcher/minecraft/services/SkinDelete.cpp
+++ b/launcher/minecraft/services/SkinDelete.cpp
@@ -4,6 +4,7 @@
 #include <QHttpMultiPart>
 
 #include "Application.h"
+#include "BuildConfig.h"
 
 SkinDelete::SkinDelete(QObject *parent, QString token)
     : Task(parent), m_token(token)
@@ -12,7 +13,7 @@ SkinDelete::SkinDelete(QObject *parent, QString token)
 
 void SkinDelete::executeTask()
 {
-    QNetworkRequest request(QUrl("https://api.minecraftservices.com/minecraft/profile/skins/active"));
+    QNetworkRequest request(QString("%1/minecraft/profile/skins/active").arg(BuildConfig.API_BASE));
     request.setRawHeader("Authorization", QString("Bearer %1").arg(m_token).toLocal8Bit());
     QNetworkReply *rep = APPLICATION->network()->deleteResource(request);
     m_reply = shared_qobject_ptr<QNetworkReply>(rep);

--- a/launcher/minecraft/services/SkinUpload.cpp
+++ b/launcher/minecraft/services/SkinUpload.cpp
@@ -4,6 +4,7 @@
 #include <QHttpMultiPart>
 
 #include "Application.h"
+#include "BuildConfig.h"
 
 QByteArray getVariant(SkinUpload::Model model) {
     switch (model) {
@@ -23,7 +24,7 @@ SkinUpload::SkinUpload(QObject *parent, QString token, QByteArray skin, SkinUplo
 
 void SkinUpload::executeTask()
 {
-    QNetworkRequest request(QUrl("https://api.minecraftservices.com/minecraft/profile/skins"));
+    QNetworkRequest request(QString("%1/minecraft/profile/skins").arg(BuildConfig.API_BASE));
     request.setRawHeader("Authorization", QString("Bearer %1").arg(m_token).toLocal8Bit());
     QHttpMultiPart *multiPart = new QHttpMultiPart(QHttpMultiPart::FormDataType);
 

--- a/launcher/ui/dialogs/ProfileSetupDialog.cpp
+++ b/launcher/ui/dialogs/ProfileSetupDialog.cpp
@@ -28,6 +28,7 @@
 #include "minecraft/auth/AuthRequest.h"
 #include "minecraft/auth/Parsers.h"
 
+#include "BuildConfig.h"
 
 ProfileSetupDialog::ProfileSetupDialog(MinecraftAccountPtr accountToSetup, QWidget *parent)
     : QDialog(parent), m_accountToSetup(accountToSetup), ui(new Ui::ProfileSetupDialog)
@@ -134,7 +135,7 @@ void ProfileSetupDialog::checkName(const QString &name) {
 
     auto token = m_accountToSetup->accessToken();
 
-    auto url = QString("https://api.minecraftservices.com/minecraft/profile/name/%1/available").arg(name);
+    auto url = QString("%1/minecraft/profile/name/%2/available").arg(BuildConfig.API_BASE).arg(name);
     QNetworkRequest request = QNetworkRequest(url);
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     request.setRawHeader("Accept", "application/json");
@@ -183,7 +184,7 @@ void ProfileSetupDialog::setupProfile(const QString &profileName) {
 
     auto token = m_accountToSetup->accessToken();
 
-    auto url = QString("https://api.minecraftservices.com/minecraft/profile");
+    auto url = QString("%1/minecraft/profile");
     QNetworkRequest request = QNetworkRequest(url);
     request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     request.setRawHeader("Accept", "application/json");


### PR DESCRIPTION
This makes it easy to change these URLs to custom Yggdrasil-compatible authentication servers, which can be used by users who do not want to use Microsoft authentication servers due to privacy issues (e.g., chat reporting feature, etc).