### PR TITLE
NOISSUE Fix valid account check when starting instance

### DIFF
--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -78,7 +78,7 @@ void LaunchController::decideAccount()
         if (reply == QMessageBox::Yes)
         {
             // Open the account manager.
-            APPLICATION->ShowGlobalSettings(m_parentWidget, "accounts");
+            APPLICATION->ShowAccountsDialog(m_parentWidget);
         }
     }
 

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -51,9 +51,18 @@ void LaunchController::decideAccount()
         return;
     }
 
-    // Find an account to use.
+    // Find a valid account to use.
     auto accounts = APPLICATION->accounts();
-    if (accounts->count() <= 0)
+    bool hasAValidAccount = false;
+    for (int i = 0; i < accounts.get()->count(); i++) {
+        auto currentAccount = accounts.get()->at(i);
+        if (currentAccount.isAccount && currentAccount.account != nullptr) {
+            hasAValidAccount = true;
+            break;
+        }
+    }
+
+    if (!hasAValidAccount)
     {
         // Tell the user they need to log in at least one account in order to play.
         auto reply = CustomMessageBox::selectable(

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -68,8 +68,8 @@ void LaunchController::decideAccount()
         auto reply = CustomMessageBox::selectable(
             m_parentWidget,
             tr("No Accounts"),
-            tr("In order to play Minecraft, you must have at least one Mojang or Minecraft "
-               "account logged in."
+            tr("In order to play Minecraft, you must have at least one Minecraft account "
+               "logged in. "
                "Would you like to open the account manager to add an account now?"),
             QMessageBox::Information,
             QMessageBox::Yes | QMessageBox::No


### PR DESCRIPTION
Thanks to phit on Discord for reporting the first issue and doing the initial investigation.

This PR fixes three issues:

1. The "no accounts" message box no longer being displayed.
2. In the "no accounts" message box, a missing space has been added and the "Mojang account" part has been removed since the whole migration thingy is over.
3. And finally, if the user click the "Yes" button in the "no accounts" message box, they are properly redirected to the new/current "Accounts" dialog instead of the old one that no longer exists (the one in the "global settings" dialog).

About the fix for issue number 1: I tried a more "elegant fix" by getting rid of the "dummy" account that is created when MultiMC starts but I went into issues like crashes with an account is already set up. I'm not very familiar with MultiMC's codebase so I went with the hypothesis that this "dummy" account was "needed" and I went with the alternative that you see in this PR.

If this PR should have been divided into three distinct PRs, let me know and I'll split them.