### PR TITLE
Update console notification for Java 25

### DIFF
--- a/launcher/minecraft/VersionFilterData.cpp
+++ b/launcher/minecraft/VersionFilterData.cpp
@@ -70,7 +70,7 @@ VersionFilterData::VersionFilterData()
     java16BeginsDate    = timeFromS3Time("2021-05-12T11:19:15+00:00");
     java17BeginsDate    = timeFromS3Time("2021-11-16T17:04:48+00:00");
     java21BeginsDate    = timeFromS3Time("2024-04-03T11:49:39+00:00");
-    java25BeginsDate    = timeFromS3Time("2025-12-16T00:00:11+00:00");
+    java25BeginsDate    = timeFromS3Time("2025-12-16T12:42:29+00:00");
     quickPlayBeginsDate = timeFromS3Time("2023-04-05T12:05:17+00:00");
     liteLoaderEndsDate  = timeFromS3Time("2017-09-18T08:39:46+00:00");
     fabricBeginsDate    = timeFromS3Time("2019-04-23T14:52:44+00:00");

--- a/launcher/minecraft/VersionFilterData.cpp
+++ b/launcher/minecraft/VersionFilterData.cpp
@@ -70,6 +70,7 @@ VersionFilterData::VersionFilterData()
     java16BeginsDate    = timeFromS3Time("2021-05-12T11:19:15+00:00");
     java17BeginsDate    = timeFromS3Time("2021-11-16T17:04:48+00:00");
     java21BeginsDate    = timeFromS3Time("2024-04-03T11:49:39+00:00");
+    java25BeginsDate    = timeFromS3Time("2025-12-16T00:00:11+00:00");
     quickPlayBeginsDate = timeFromS3Time("2023-04-05T12:05:17+00:00");
     liteLoaderEndsDate  = timeFromS3Time("2017-09-18T08:39:46+00:00");
     fabricBeginsDate    = timeFromS3Time("2019-04-23T14:52:44+00:00");

--- a/launcher/minecraft/VersionFilterData.h
+++ b/launcher/minecraft/VersionFilterData.h
@@ -30,6 +30,8 @@ struct VersionFilterData
     // Release data of the first version to require java 21 (24w14a)
     QDateTime java21BeginsDate;
     // release date of first version to use --quickPlayMultiplayer instead of --server/--port for directly joining servers
+    QDateTime java25BeginsDate;
+    // release date of first version to require java 25 (26.1 Snapshot 1) and new "year.drop.hotfix" version format
     QDateTime quickPlayBeginsDate;
     // release date of last version to support LiteLoader (1.12.2)
     QDateTime liteLoaderEndsDate;

--- a/launcher/minecraft/launch/VerifyJavaInstall.cpp
+++ b/launcher/minecraft/launch/VerifyJavaInstall.cpp
@@ -34,6 +34,15 @@ void VerifyJavaInstall::executeTask() {
     auto javaVersion = m_inst->getJavaVersion();
     auto minecraftComponent = m_inst->getPackProfile()->getComponent("net.minecraft");
 
+    // Java 25 Requirement
+    if (minecraftComponent->getReleaseDateTime() >= g_VersionFilterData.java25BeginsDate) {
+        if (javaVersion.major() < 21) {
+            emit logLine("Minecraft 26.1 Snapshot 1 and above require the use of Java 25",
+                         MessageLevel::Fatal);
+            emitFailed(tr("Minecraft 26.1 Snapshot 1 and above require the use of Java 25"));
+            return;
+        }
+    }    
     // Java 21 Requirement
     if (minecraftComponent->getReleaseDateTime() >= g_VersionFilterData.java21BeginsDate) {
         if (javaVersion.major() < 21) {


### PR DESCRIPTION
Update filters to match changes starting with 26.1 snapshots and Java requirements.