### PR TITLE
Perform modpack type detection as needed

### DIFF
--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -102,30 +102,37 @@ void InstanceImportTask::processZipPack()
 
     QStringList blacklist = {"instance.cfg", "manifest.json"};
     QString mmcFound = MMCZip::findFolderOfFileInZip(m_packZip.get(), "instance.cfg");
-    bool technicFound = QuaZipDir(m_packZip.get()).exists("/bin/modpack.jar") || QuaZipDir(m_packZip.get()).exists("/bin/version.json");
-    QString modrinthFound = MMCZip::findFolderOfFileInZip(m_packZip.get(), "modrinth.index.json");
+
     QString root;
-    if(!mmcFound.isNull())
+    if (!mmcFound.isNull())
     {
         // process as MultiMC instance/pack
         qDebug() << "MultiMC:" << mmcFound;
         root = mmcFound;
         m_modpackType = ModpackType::MultiMC;
     }
-    else if (technicFound)
-    {
-        // process as Technic pack
-        qDebug() << "Technic:" << technicFound;
-        extractDir.mkpath(".minecraft");
-        extractDir.cd(".minecraft");
-        m_modpackType = ModpackType::Technic;
+    if (m_modpackType == ModpackType::Unknown) {
+        bool technicFound = QuaZipDir(m_packZip.get()).exists("/bin/modpack.jar") || QuaZipDir(m_packZip.get()).exists("/bin/version.json");
+        if (technicFound)
+        {
+            // process as Technic pack
+            qDebug() << "Technic:" << technicFound;
+            extractDir.mkpath(".minecraft");
+            extractDir.cd(".minecraft");
+            m_modpackType = ModpackType::Technic;
+        }
     }
-    else if(!modrinthFound.isNull())
+    if (m_modpackType == ModpackType::Unknown)
     {
-        // process as Modrinth pack
-        qDebug() << "Modrinth:" << modrinthFound;
-        root = modrinthFound;
-        m_modpackType = ModpackType::Modrinth;
+        QString modrinthFound = MMCZip::findFolderOfFileInZip(m_packZip.get(), "modrinth.index.json");
+
+        if(!modrinthFound.isNull())
+        {
+            // process as Modrinth pack
+            qDebug() << "Modrinth:" << modrinthFound;
+            root = modrinthFound;
+            m_modpackType = ModpackType::Modrinth;
+        }
     }
     if(m_modpackType == ModpackType::Unknown)
     {


### PR DESCRIPTION
Hi,

I have encountered a performance issue with import performance of a large modpack exported with MultiMC.

```
1.1 GiB (1,149,869,013)
7,492 files, 1,411 sub-folders
```

Profiling pointed me to `findFolderOfFileInZip` method.

Currently all classifications are performed regardless if they are needed based on the priority logic.
With this change specific modpack classifications are performed as needed. This limits the number of calls to `findFolderOfFileInZip` during zip import.

For my case and hardware it brings the import time down from 36 seconds to 2 seconds.

While this code change is far from a perfect solution, I believe it's a step in the right direction.
I'm not a C++ developer, so I'm not sure what would be a good way to speed up zip traversal in this context.